### PR TITLE
Refactor Token Refresh Api (experimental api changes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Android implementation is [AndroidEncryptedPreferencesSettingsStore](https://kal
 ```kotlin
 val authenticator = OpenIdConnectAuthenticator {
     getAccessToken { tokenStore.getAccessToken() }
-    refreshTokens { oldAccessToken -> refreshHandler.safeRefreshToken(client, oldAccessToken) }
+    refreshTokens { oldAccessToken -> refreshHandler.refreshAndSaveToken(client, oldAccessToken) }
     onRefreshFailed {
         // provided by app: user has to authenticate again
     }

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ tokenstore.saveTokens(tokens)
 val accessToken = tokenstore.getAccessToken()
 
 val refreshHandler = TokenRefreshHandler(tokenStore = tokenstore)
-refreshHandler.safeRefreshToken(client, oldAccessToken = accessToken) // thread-safe refresh and save new tokens to store
+refreshHandler.refreshAndSaveToken(client, oldAccessToken = token) // thread-safe refresh and save new tokens to store
 ```
 Android implementation is [AndroidEncryptedPreferencesSettingsStore](https://kalinjul.github.io/kotlin-multiplatform-oidc/kotlin-multiplatform-oidc/org.publicvalue.multiplatform.oidc.tokenstore/-android-encrypted-preferences-settings-store/index.html), for iOS use [IosKeychainTokenStore](https://kalinjul.github.io/kotlin-multiplatform-oidc/kotlin-multiplatform-oidc/org.publicvalue.multiplatform.oidc.tokenstore/-ios-keychain-token-store/index.html).
 

--- a/oidc-okhttp4/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/okhttp/DefaultOpenIdConnectAuthenticator.kt
+++ b/oidc-okhttp4/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/okhttp/DefaultOpenIdConnectAuthenticator.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.runBlocking
 import okhttp3.Request
 import org.publicvalue.multiplatform.oidc.ExperimentalOpenIdConnect
 import org.publicvalue.multiplatform.oidc.OpenIdConnectClient
+import org.publicvalue.multiplatform.oidc.tokenstore.OauthTokens
 import org.publicvalue.multiplatform.oidc.tokenstore.TokenRefreshHandler
 import org.publicvalue.multiplatform.oidc.tokenstore.TokenStore
 import org.publicvalue.multiplatform.oidc.tokenstore.removeTokens
@@ -15,16 +16,16 @@ import org.publicvalue.multiplatform.oidc.tokenstore.removeTokens
 @ExperimentalOpenIdConnect
 @Suppress("unused")
 open class DefaultOpenIdConnectAuthenticator(
-    val tokenStore: TokenStore,
-    val refreshHandler: TokenRefreshHandler,
-    val client: OpenIdConnectClient
+    open val tokenStore: TokenStore,
+    open val refreshHandler: TokenRefreshHandler,
+    open val client: OpenIdConnectClient
 ): OpenIdConnectAuthenticator() {
     override suspend fun getAccessToken(): String? {
         return tokenStore.getAccessToken()
     }
 
-    override suspend fun refreshTokens(oldAccessToken: String) {
-        refreshHandler.safeRefreshToken(client, oldAccessToken)
+    override suspend fun refreshTokens(oldAccessToken: String): OauthTokens? {
+        return refreshHandler.refreshAndSaveToken(client, oldAccessToken)
     }
 
     override fun onRefreshFailed() {

--- a/oidc-okhttp4/src/commonTest/kotlin/org/publicvalue/multiplatform/oidc/okhttp/README.kt
+++ b/oidc-okhttp4/src/commonTest/kotlin/org/publicvalue/multiplatform/oidc/okhttp/README.kt
@@ -18,7 +18,7 @@ object Readme {
         @OptIn(ExperimentalOpenIdConnect::class)
         val authenticator = OpenIdConnectAuthenticator {
             getAccessToken { tokenStore.getAccessToken() }
-            refreshTokens { oldAccessToken -> refreshHandler.safeRefreshToken(client, oldAccessToken) }
+            refreshTokens { oldAccessToken -> refreshHandler.refreshAndSaveToken(client, oldAccessToken) }
             onRefreshFailed {
                 // provided by app: user has to authenticate again
             }

--- a/oidc-tokenstore/build.gradle.kts
+++ b/oidc-tokenstore/build.gradle.kts
@@ -32,6 +32,7 @@ kotlin {
                 implementation(kotlin("test"))
                 implementation(libs.assertk)
                 implementation(libs.kotlinx.coroutines.test)
+                implementation(projects.oidcAppsupport) // for readme
             }
         }
     }

--- a/oidc-tokenstore/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/tokenstore/OauthTokens.kt
+++ b/oidc-tokenstore/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/tokenstore/OauthTokens.kt
@@ -1,0 +1,7 @@
+package org.publicvalue.multiplatform.oidc.tokenstore
+
+data class OauthTokens(
+    val accessToken: String,
+    val refreshToken: String?,
+    val idToken: String?
+)

--- a/oidc-tokenstore/src/commonTest/kotlin/org/publicvalue/multiplatform/oidc/tokenstore/README.kt
+++ b/oidc-tokenstore/src/commonTest/kotlin/org/publicvalue/multiplatform/oidc/tokenstore/README.kt
@@ -94,6 +94,6 @@ object README {
     @OptIn(ExperimentalOpenIdConnect::class)
     suspend fun `refresh_handler`() {
         val refreshHandler = TokenRefreshHandler(tokenStore = tokenstore)
-        refreshHandler.safeRefreshToken(client, oldAccessToken = token) // thread-safe refresh and save new tokens to store
+        refreshHandler.refreshAndSaveToken(client, oldAccessToken = token) // thread-safe refresh and save new tokens to store
     }
 }

--- a/oidc-tokenstore/src/iosMain/kotlin/org/publicvalue/multiplatform/oidc/tokenstore/TokenRefreshHandler+iOS.kt
+++ b/oidc-tokenstore/src/iosMain/kotlin/org/publicvalue/multiplatform/oidc/tokenstore/TokenRefreshHandler+iOS.kt
@@ -14,8 +14,8 @@ import kotlin.coroutines.cancellation.CancellationException
 @OptIn(ExperimentalOpenIdConnect::class)
 @Throws(OpenIdConnectException::class, CancellationException::class)
 @Suppress("unused")
-suspend fun TokenRefreshHandler.safeRefreshToken(refresher: TokenRefresher, oldAccessToken: String): String {
-    return safeRefreshToken(
+suspend fun TokenRefreshHandler.safeRefreshToken(refresher: TokenRefresher, oldAccessToken: String): OauthTokens {
+    return refreshAndSaveToken(
         refreshCall = { refreshToken ->
             refresher.refreshToken(refreshToken = refreshToken)
         },

--- a/sample-app/shared/src/androidMain/kotlin/ReadmeAndroid.kt
+++ b/sample-app/shared/src/androidMain/kotlin/ReadmeAndroid.kt
@@ -17,7 +17,7 @@ object ReadmeAndroid {
     suspend fun `okhttp`() {
         val authenticator = OpenIdConnectAuthenticator {
             getAccessToken { tokenStore.getAccessToken() }
-            refreshTokens { oldAccessToken -> refreshHandler.safeRefreshToken(client, oldAccessToken) }
+            refreshTokens { oldAccessToken -> refreshHandler.refreshAndSaveToken(client, oldAccessToken) }
             onRefreshFailed {
                 // provided by app: user has to authenticate again
             }


### PR DESCRIPTION
refactor: 
okhttp/ktor: token refresh returns OauthTokens, 
rename to refreshAndSaveToken()

Experimental api changes!