### PR TITLE
ASWebAuthenticationSession.prefersEphemeralWebBrowserSession to false

### DIFF
--- a/oidc-appsupport/src/iosMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/PlatformOidcCodeAuthFlow.ios.kt
+++ b/oidc-appsupport/src/iosMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/PlatformOidcCodeAuthFlow.ios.kt
@@ -60,7 +60,7 @@ actual class PlatformCodeAuthFlow(
                         }
                     }
                 )
-                session.prefersEphemeralWebBrowserSession = true
+                session.prefersEphemeralWebBrowserSession = false
                 session.presentationContextProvider = PresentationContext()
 
                 MainScope().launch {


### PR DESCRIPTION
set prefersEphemeralWebBrowserSession to false.
The behaviour is different from android implementation where the cookies/login information is persisted between getAuthorizationCode flows.
It means on android the second time the user doesn't have to enter their username/password, while on iOS the user has to do it every time.