### PR TITLE
Add ephemeralBrowserSession parameter with default set to false

### DIFF
--- a/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/AndroidCodeAuthFlowFactory.kt
+++ b/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/AndroidCodeAuthFlowFactory.kt
@@ -24,6 +24,8 @@ import org.publicvalue.multiplatform.oidc.flows.CodeAuthFlow
 class AndroidCodeAuthFlowFactory(
     /** If true, uses an embedded WebView instead of Chrome CustomTab (not recommended) **/
     private val useWebView: Boolean = false,
+    /** Clear cache and cookies in WebView **/
+    private val webViewEpheremalSession: Boolean = false
 ): CodeAuthFlowFactory {
 
     lateinit var authRequestLauncher: ActivityResultLauncherSuspend<Intent, ActivityResult>
@@ -69,7 +71,8 @@ class AndroidCodeAuthFlowFactory(
             context = context,
             contract = authRequestLauncher,
             client = client,
-            useWebView = useWebView
+            useWebView = useWebView,
+            webViewEpheremalSession = webViewEpheremalSession
         )
     }
 }

--- a/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/PlatformOidcCodeAuthFlow.android.kt
+++ b/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/PlatformOidcCodeAuthFlow.android.kt
@@ -15,6 +15,7 @@ actual class PlatformCodeAuthFlow(
     private val context: Context,
     private val contract: ActivityResultLauncherSuspend<Intent, ActivityResult>,
     private val useWebView: Boolean = false,
+    private val webViewEpheremalSession: Boolean = false,
     client: OpenIdConnectClient,
 ) : CodeAuthFlow(client) {
 
@@ -28,6 +29,7 @@ actual class PlatformCodeAuthFlow(
             if (useWebView) {
                 this.putExtra(EXTRA_KEY_USEWEBVIEW, true)
                 this.putExtra(EXTRA_KEY_REDIRECTURL, request.url.parameters.get("redirect_uri"))
+                this.putExtra(EXTRA_KEY_WEBVIEW_EPHEREMAL_SESSION, webViewEpheremalSession)
             }
         }
         val result = contract.launchSuspend(intent)

--- a/oidc-appsupport/src/iosMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/IosCodeAuthFlowFactory.kt
+++ b/oidc-appsupport/src/iosMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/IosCodeAuthFlowFactory.kt
@@ -7,8 +7,9 @@ import kotlin.experimental.ExperimentalObjCRefinement
 @HiddenFromObjC
 @Suppress("unused")
 class IosCodeAuthFlowFactory(
+    private val ephemeralBrowserSession: Boolean = false
 ): CodeAuthFlowFactory {
     override fun createAuthFlow(client: OpenIdConnectClient): PlatformCodeAuthFlow {
-        return PlatformCodeAuthFlow(client)
+        return PlatformCodeAuthFlow(client, ephemeralBrowserSession)
     }
 }

--- a/oidc-appsupport/src/iosMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/PlatformOidcCodeAuthFlow.ios.kt
+++ b/oidc-appsupport/src/iosMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/PlatformOidcCodeAuthFlow.ios.kt
@@ -1,7 +1,6 @@
 package org.publicvalue.multiplatform.oidc.appsupport
 
 import io.ktor.http.Url
-import io.ktor.http.hostWithPort
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import org.publicvalue.multiplatform.oidc.OpenIdConnectClient
@@ -33,7 +32,8 @@ import kotlin.experimental.ExperimentalObjCName
 @OptIn(ExperimentalObjCName::class)
 @ObjCName(swiftName = "CodeAuthFlow", name = "CodeAuthFlow", exact = true)
 actual class PlatformCodeAuthFlow(
-    client: OpenIdConnectClient
+    client: OpenIdConnectClient,
+    private val ephemeralBrowserSession: Boolean = false
 ): CodeAuthFlow(client) {
     override suspend fun getAuthorizationCode(request: AuthCodeRequest): AuthCodeResponse = wrapExceptions {
         val authResponse = suspendCoroutine { continuation ->
@@ -60,7 +60,7 @@ actual class PlatformCodeAuthFlow(
                         }
                     }
                 )
-                session.prefersEphemeralWebBrowserSession = true
+                session.prefersEphemeralWebBrowserSession = ephemeralBrowserSession
                 session.presentationContextProvider = PresentationContext()
 
                 MainScope().launch {

--- a/oidc-core/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/ExperimentalOpenIdConnect.kt
+++ b/oidc-core/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/ExperimentalOpenIdConnect.kt
@@ -2,5 +2,5 @@ package org.publicvalue.multiplatform.oidc
 
 @RequiresOptIn(message = "This API is experimental. It may be changed in the future without notice.", level = RequiresOptIn.Level.WARNING)
 @Retention(AnnotationRetention.BINARY)
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
 annotation class ExperimentalOpenIdConnect


### PR DESCRIPTION
On iOS, the default is now false, as it already was for Android. This allows login without interaction if cookies are present. For Android, this introduces webViewEpheremalSession (default false), which can be used for webView authorization.