### PR TITLE
Lower min SDK to 21

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 compileSdk = "34"
 targetSdk = "34"
-minSdk = "26"
+minSdk = "21"
 
 jvmTarget = "17"
 # https://developer.android.com/build/releases/gradle-plugin#compatibility

--- a/oidc-okhttp4/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/okhttp/OpenIdConnectAuthenticator.kt
+++ b/oidc-okhttp4/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/okhttp/OpenIdConnectAuthenticator.kt
@@ -10,7 +10,7 @@ import okhttp3.Route
 import org.publicvalue.multiplatform.oidc.ExperimentalOpenIdConnect
 import org.publicvalue.multiplatform.oidc.tokenstore.OauthTokens
 
-private val LOG_TAG = "OpenIdConnectAuthenticator"
+private val LOG_TAG = "OIDCAuthenticator"
 
 /**
  * OkHttp Authenticator.


### PR DESCRIPTION
MinSDK 21 should be no problem. okhttp needs 21, everything else seems to have even lower requirements.

See #32