### PR TITLE
Expose api for swift to install ktor plugins

### DIFF
--- a/docs/ios/README.md
+++ b/docs/ios/README.md
@@ -45,7 +45,24 @@ let client = OpenIdConnectClient(
     )
 )
 ```
-If you provide a Discovery URI, you may skip the endpoint configuration.
+If you provide a Discovery URI, you may skip the endpoint configuration and set endpoints to nil.
+If required, you can also configure the http client with custom headers etc:
+
+```swift
+let client = OpenIdConnectClient(
+    httpClient: OpenIdConnectClient.companion.DefaultHttpClient.config(block: { config in
+        config.installClientPlugin(
+            name: "customheader",
+            onRequest: { requestBuilder, content in
+                requestBuilder.headers.append(name: "User-Agent", value: "oidcclient")
+            },
+            onResponse: {_ in},
+            onClose: {}
+        )
+    }),
+    config: ...
+)
+```
 
 Request access token using code auth flow:
 ```swift 

--- a/oidc-core/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/OpenIdConnectClient.kt
+++ b/oidc-core/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/OpenIdConnectClient.kt
@@ -64,15 +64,20 @@ interface OpenIdConnectClient {
      * Updates the configuration, but will keep any existing configuration.
      *
      * See: [OpenID Connect Discovery](https://openid.net/specs/openid-connect-discovery-1_0.html)
+     *
+     * @param configure configuration closure to configure the http request builder with
      */
     @Throws(OpenIdConnectException::class, CancellationException::class)
-    suspend fun discover()
+    suspend fun discover(configure: (HttpRequestBuilder.() -> Unit)? = null)
 
     /**
      * RP-initiated logout.
      * Just performs the GET request for logout, we skip the redirect part for convenience.
      *
      * See: [OpenID Spec](https://openid.net/specs/openid-connect-rpinitiated-1_0.html)
+     *
+     * @param configure configuration closure to configure the http request builder with (will _not_
+     * be used for discovery if necessary)
      */
     @Throws(OpenIdConnectException::class, CancellationException::class)
     suspend fun endSession(
@@ -87,7 +92,8 @@ interface OpenIdConnectClient {
      *
      * @param authCodeRequest the original request for auth code
      * @param code the authcode received via redirect
-     * @param configure configuration closure for the HTTP request
+     * @param configure configuration closure for the HTTP request (will _not_  be used for
+     * discovery if necessary)
      *
      * @return [AccessTokenResponse]
      */
@@ -103,7 +109,8 @@ interface OpenIdConnectClient {
      * [RFC6749](https://datatracker.ietf.org/doc/html/rfc6749#section-6)
      *
      * @param refreshToken the refresh token
-     * @param configure configuration closure for the HTTP request
+     * @param configure configuration closure for the HTTP request (will _not_  be used for
+     * discovery if necessary)
      *
      * @return [AccessTokenResponse]
      */
@@ -137,7 +144,8 @@ interface OpenIdConnectClient {
      * You should use [OpenIdConnectClient.refreshToken] for creating and executing a request instead.
      *
      * @param refreshToken the refresh token
-     * @param configure configuration closure for the HTTP request
+     * @param configure configuration closure for the HTTP request (will _not_  be used for
+     * discovery if necessary)
      *
      * @return [TokenRequest]
      */

--- a/oidc-core/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/discovery/OpenIdConnectDiscover.kt
+++ b/oidc-core/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/discovery/OpenIdConnectDiscover.kt
@@ -2,6 +2,7 @@ package org.publicvalue.multiplatform.oidc.discovery
 
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.get
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.Url
@@ -32,20 +33,24 @@ class OpenIdConnectDiscover(
      * Retrieve configuration document from url.
      *
      * @param configurationUrl the url
+     * @param configure configuration closure to configure the http request builder with
      * @return [OpenIdConnectConfiguration]
      */
-    suspend fun downloadConfiguration(configurationUrl: String): OpenIdConnectConfiguration {
-        return downloadConfiguration(Url(configurationUrl))
+    suspend fun downloadConfiguration(configurationUrl: String, configure: (HttpRequestBuilder.() -> Unit)? = null): OpenIdConnectConfiguration {
+        return downloadConfiguration(Url(configurationUrl), configure)
     }
 
     /**
      * Retrieve configuration document from url.
      *
      * @param configurationUrl the url
+     * @param configure configuration closure to configure the http request builder with
      * @return [OpenIdConnectConfiguration]
      */
-    suspend fun downloadConfiguration(configurationUrl: Url): OpenIdConnectConfiguration {
-        val result = httpClient.get(configurationUrl)
+    suspend fun downloadConfiguration(configurationUrl: Url, configure: (HttpRequestBuilder.() -> Unit)? = null): OpenIdConnectConfiguration {
+        val result = httpClient.get(configurationUrl) {
+            configure?.invoke(this)
+        }
         val configuration: OpenIdConnectConfiguration = result.forceUnwrapBody(json)
         return configuration
     }

--- a/oidc-core/src/iosMain/kotlin/org/publicvalue/multiplatform/oidc/OpenIdConnectClientConvenienceExtensions.kt
+++ b/oidc-core/src/iosMain/kotlin/org/publicvalue/multiplatform/oidc/OpenIdConnectClientConvenienceExtensions.kt
@@ -1,11 +1,24 @@
 @file:Suppress("Unused")
 package org.publicvalue.multiplatform.oidc
 
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.plugins.api.createClientPlugin
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.statement.HttpResponse
 import org.publicvalue.multiplatform.oidc.types.AuthCodeRequest
 import kotlin.coroutines.cancellation.CancellationException
 
 // swift convenience overloads with default parameters for suspend functions
 // defined on DefaultOpenIdConnectClient because we cannot export extensions for interfaces yet
+
+/**
+ * Objective-C convenience function
+ * @see OpenIdConnectClient.exchangeToken
+ * @suppress
+ */
+@Throws(OpenIdConnectException::class, CancellationException::class)
+suspend fun DefaultOpenIdConnectClient.discover() =
+    discover(null)
 
 /**
  * Objective-C convenience function
@@ -51,3 +64,27 @@ suspend fun DefaultOpenIdConnectClient.createRefreshTokenRequest(refreshToken: S
 @Throws(OpenIdConnectException::class, CancellationException::class)
 suspend fun DefaultOpenIdConnectClient.refreshToken(refreshToken: String) =
     refreshToken(refreshToken, null)
+
+/**
+ * Create and install a custom client plugin.
+ * @suppress
+ */
+fun HttpClientConfig<*>.installClientPlugin(name: String,
+                                            onRequest: (HttpRequestBuilder, Any) -> Unit = {_,_ ->},
+                                            onResponse: (HttpResponse) -> Unit = {},
+                                            onClose: () -> Unit = {},
+) {
+    val plugin = createClientPlugin(name, body = {
+            onRequest { request, content ->
+                onRequest(request, content)
+            }
+            onResponse {
+                onResponse(it)
+            }
+            onClose {
+                onClose()
+            }
+        }
+    )
+    install(plugin)
+}

--- a/oidc-core/src/iosMain/kotlin/org/publicvalue/multiplatform/oidc/flows/CodeAuthFlowConvenienceExtensions.kt
+++ b/oidc-core/src/iosMain/kotlin/org/publicvalue/multiplatform/oidc/flows/CodeAuthFlowConvenienceExtensions.kt
@@ -1,0 +1,11 @@
+package org.publicvalue.multiplatform.oidc.flows
+
+import org.publicvalue.multiplatform.oidc.OpenIdConnectException
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Objective-C convenience function
+ * @see CodeAuthFlow.getAccessToken
+ */
+@Throws(OpenIdConnectException::class, CancellationException::class)
+suspend fun CodeAuthFlow.getAccessToken() = getAccessToken(null)

--- a/sample-app/ios-app/iosApp/Readme.swift
+++ b/sample-app/ios-app/iosApp/Readme.swift
@@ -28,6 +28,32 @@ struct Readme {
         )
     }
     
+    // Create OpenID client with custom http client configuration:
+    func _1b() {
+        let client = OpenIdConnectClient(
+            httpClient: OpenIdConnectClient.companion.DefaultHttpClient.config(block: { config in
+                config.installClientPlugin(
+                    name: "customheader",
+                    onRequest: { requestBuilder, content in
+                        requestBuilder.headers.append(name: "User-Agent", value: "oidcclient")
+                    },
+                    onResponse: {_ in},
+                    onClose: {}
+                )
+            }),
+            config: OpenIdConnectClientConfig(
+                discoveryUri: "<discovery url>",
+                endpoints: nil,
+                clientId: "<clientId>",
+                clientSecret: "<clientSecret>",
+                scope: "openid profile",
+                codeChallengeMethod: .s256,
+                redirectUri: "<redirectUri>"
+            )
+            
+        )
+    }
+    
     // Request access token using code auth flow:
     func _2() async {
         let flow = CodeAuthFlow(client: client)
@@ -40,6 +66,10 @@ struct Readme {
     
     // Perform refresh or endSession:
     func _3() async throws {
+        try await client.refreshToken(refreshToken: "") { builder in
+            builder.headers.append(name: "Accept", value: "application/json")
+            builder.build()
+        }
         try await client.refreshToken(refreshToken: tokens.refresh_token!)
         try await client.endSession(idToken: tokens.id_token!)
     }


### PR DESCRIPTION
In swift, it was not possible to create custom ktor plugins.
This exposes a custom api to swift to be able to create and install custom (e.g. header) plugins, see Readme.
Should fix #39.