### PR TITLE
fix: Don't send empty bearer when there is no token in tokenstore

### DIFF
--- a/oidc-ktor/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/ktor/ConfigureAuthPlugin.kt
+++ b/oidc-ktor/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/ktor/ConfigureAuthPlugin.kt
@@ -70,16 +70,12 @@ fun BearerAuthConfig.loadTokens(tokenStore: TokenStore) {
     loadTokens {
         val accessToken = tokenStore.getAccessToken()
         val refreshToken = tokenStore.getRefreshToken()
-        val bearer = accessToken?.let {
+        accessToken?.let {
             BearerTokens(
                 accessToken = it,
                 refreshToken = refreshToken ?: "",
             )
-        } ?: BearerTokens(
-            accessToken = "",
-            refreshToken = ""
-        )
-        bearer
+        }
     }
 }
 


### PR DESCRIPTION
Hi, thanks for getting into this project!

Checklist for your PR:
- [x] Check if there's any open issue
- [x] Please file your request against the _develop_ branch

# Description of your changes
When the access token in the token store is empty Ktor sends an empty bearer. Some servers misunderstood it and this change avoids it by deleting it when the access token doesn't exist

# How has this been tested?
API requests

# Is this a (API-) breaking change?
No
