### PR TITLE
fix: failure on backup restore

### DIFF
--- a/oidc-appsupport/src/androidMain/AndroidManifest.xml
+++ b/oidc-appsupport/src/androidMain/AndroidManifest.xml
@@ -14,7 +14,9 @@
         </intent>
     </queries>
 
-    <application>
+    <application
+        android:fullBackupContent="@xml/backup_rules"
+        android:dataExtractionRules="@xml/data_extraction_rules">
     <activity
         android:name=".HandleRedirectActivity"
         android:exported="true"

--- a/oidc-appsupport/src/androidMain/res/xml/backup_rules.xml
+++ b/oidc-appsupport/src/androidMain/res/xml/backup_rules.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <exclude domain="sharedpref" path="org.publicvalue.multiplatform.oidc.tokenstore.xml"/>
+</full-backup-content>

--- a/oidc-appsupport/src/androidMain/res/xml/data_extraction_rules.xml
+++ b/oidc-appsupport/src/androidMain/res/xml/data_extraction_rules.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="sharedpref" path="org.publicvalue.multiplatform.oidc.tokenstore.xml"/>
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="sharedpref" path="org.publicvalue.multiplatform.oidc.tokenstore.xml"/>
+    </device-transfer>
+</data-extraction-rules>

--- a/oidc-tokenstore/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/tokenstore/AndroidEncryptedPreferencesSettingsStore.kt
+++ b/oidc-tokenstore/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/tokenstore/AndroidEncryptedPreferencesSettingsStore.kt
@@ -17,7 +17,7 @@ class AndroidEncryptedPreferencesSettingsStore(
 
     private var sharedPreferences: SharedPreferences = EncryptedSharedPreferences.create(
         context,
-        "${context.packageName}.auth",
+        "org.publicvalue.multiplatform.oidc.tokenstore",
         masterKey,
         EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
         EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM


### PR DESCRIPTION
When restoring from backup, encrypted preferences are not readable, causing apps to crash. Fix this by excluding the encrypted preferences from Android backups.

This should fix #47.
As this changes the file name of the preferences, upgrading requires re-login by users.

