### PR TITLE
Added invalid grant to the ErrorRespons Error enum

### DIFF
--- a/oidc-core/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/types/remote/ErrorResponse.kt
+++ b/oidc-core/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/types/remote/ErrorResponse.kt
@@ -7,6 +7,7 @@ import kotlin.native.ObjCName
 /**
  * ErrorResponse expected from Authorization or Token endpoint.
  * [RFC6749](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1)
+ * [RFC6749](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2)
  */
 @OptIn(ExperimentalObjCName::class)
 @ObjCName(swiftName = "OpenIdConnectErrorResponse", name = "OpenIdConnectErrorResponse", exact = true)
@@ -24,6 +25,7 @@ data class ErrorResponse(
         bad_verification_code,
         invalid_request,
         unauthorized_client,
+        unsupported_grant_type,
         access_denied,
         unsupported_response_type,
         invalid_scope,

--- a/oidc-core/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/types/remote/ErrorResponse.kt
+++ b/oidc-core/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/types/remote/ErrorResponse.kt
@@ -20,6 +20,7 @@ data class ErrorResponse(
     @Serializable
     enum class Error {
         invalid_client,
+        invalid_grant,
         bad_verification_code,
         invalid_request,
         unauthorized_client,


### PR DESCRIPTION
Hi, thanks for getting into this project!

Checklist for your PR:
- [x] Check if there's any open issue
- [x] Please file your request against the _develop_ branch

# Description of your changes
I've added the invalid_grant error code to the enum of possible errors as this is returned by keycloak.

# How has this been tested?
Being tested locally using a build of my app

# Is this a (API-) breaking change?
No
