### PR TITLE
fix: added xdg-open support when the BROWSE action is not supported

### DIFF
--- a/oidc-appsupport/src/jvmMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/PlatformCodeAuthFlow.jvm.kt
+++ b/oidc-appsupport/src/jvmMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/PlatformCodeAuthFlow.jvm.kt
@@ -76,7 +76,17 @@ fun Url.openInBrowser() {
             throw UrlOpenException(e.message, cause = e)
         }
     } else {
-        throw UrlOpenException("Desktop does not support Browse Action")
+        val result = runCatching {
+            Runtime.getRuntime()
+                .exec(arrayOf("xdg-open", toURI().toString()))
+                .waitFor()
+        }
+
+        if (result.isFailure) {
+            result.exceptionOrNull()?.let { e ->
+                throw UrlOpenException(e.message, cause = e)
+            } ?: throw UrlOpenException("Cannot open browser!")
+        }
     }
 }
 


### PR DESCRIPTION
Hi, thanks for getting into this project!

Checklist for your PR:
- [x ] Check if there's any open issue
- [x ] Please file your request against the _develop_ branch

# Description of your changes
When trying to open the browser for authentication, for some reason the Desktop.BROWSE action is not supported on KDE, so I added a bit of extra code to support the xdg-open spec or fail if it doesn't work. It should not affect those distro/DE combinations when the action is still is supported (and preferred)

# How has this been tested?
Manually, I'm running Fedora 40 KDE using firefox and temurin jvm 21. I tried other jvms with the same result, so most likely it's a KDE thing

# Is this a (API-) breaking change?
Nope
