### PR TITLE
Update to Ktor 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Library dependency versions:
 |------------------|----------------|--------------|
 | 0.11.+           | 1.9.23         | 2.3.7        |
 | 0.12.+           | 2.0.20         | 2.3.+        |
-| future version   | 2.0.20         | 3.0.+        |
+| 0.13.+           | 2.0.20         | 3.0.+        |
 Note that while the library may work with other kotlin/ktor versions, proceed at your own risk.
 
 # Dependency

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ circuit = "0.22.2"
 sqldelight = "2.0.1"
 
 okhttp = "4.12.0"
-ktor = "2.3.7"
+ktor = "3.0.1"
 
 nexus-publish-plugin = "1.3.0"
 multiplatform-swiftpackage = "2.2.1"

--- a/oidc-appsupport/src/jvmMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/webserver/SimpleKtorWebserver.kt
+++ b/oidc-appsupport/src/jvmMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/webserver/SimpleKtorWebserver.kt
@@ -2,19 +2,18 @@ package org.publicvalue.multiplatform.oidc.appsupport.webserver
 
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.application.ApplicationCall
-import io.ktor.server.application.call
 import io.ktor.server.cio.CIO
 import io.ktor.server.cio.CIOApplicationEngine
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.request.ApplicationRequest
 import io.ktor.server.response.respondText
+import io.ktor.server.routing.RoutingContext
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import org.publicvalue.multiplatform.oidc.flows.AuthCodeResult
 
 class SimpleKtorWebserver(
-    val createResponse: suspend io.ktor.util.pipeline.PipelineContext<Unit, ApplicationCall>.() -> Unit = {
+    val createResponse: suspend RoutingContext.() -> Unit = {
         call.respondText(
             status = HttpStatusCode.OK,
             text = """
@@ -47,7 +46,7 @@ class SimpleKtorWebserver(
                 }
             }
         }.apply {
-            server = this
+            server = engine
             start(wait = true)
         }
         val code = call?.queryParameters?.get("code")

--- a/oidc-ktor/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/ktor/ConfigureAuthPlugin.kt
+++ b/oidc-ktor/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/ktor/ConfigureAuthPlugin.kt
@@ -1,6 +1,6 @@
 package org.publicvalue.multiplatform.oidc.ktor
 
-import io.ktor.client.plugins.auth.Auth
+import io.ktor.client.plugins.auth.AuthConfig
 import io.ktor.client.plugins.auth.providers.BearerAuthConfig
 import io.ktor.client.plugins.auth.providers.BearerTokens
 import io.ktor.client.plugins.auth.providers.bearer
@@ -16,7 +16,7 @@ import org.publicvalue.multiplatform.oidc.tokenstore.removeTokens
  * Configure Bearer Authentication using TokenStore + RefreshHandler.
  */
 @ExperimentalOpenIdConnect
-fun Auth.oidcBearer(
+fun AuthConfig.oidcBearer(
     tokenStore: TokenStore,
     refreshHandler: TokenRefreshHandler,
     client: OpenIdConnectClient,
@@ -40,7 +40,7 @@ fun Auth.oidcBearer(
  * save it into the store.
  */
 @ExperimentalOpenIdConnect
-fun Auth.oidcBearer(
+fun AuthConfig.oidcBearer(
     tokenStore: TokenStore,
     /** receives the old access token as parameter.
      *  This function should get new tokens and save them.

--- a/oidc-ktor/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/ktor/HttpClient+clearTokens.kt
+++ b/oidc-ktor/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/ktor/HttpClient+clearTokens.kt
@@ -2,17 +2,17 @@ package org.publicvalue.multiplatform.oidc.ktor
 
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.auth.Auth
+import io.ktor.client.plugins.auth.authProvider
 import io.ktor.client.plugins.auth.providers.BearerAuthProvider
 import io.ktor.client.plugins.plugin
 
-// https://youtrack.jetbrains.com/issue/KTOR-4759/Auth-BearerAuthProvider-caches-result-of-loadToken-until-process-death
-// Force the Auth plugin to invoke the `loadTokens` block again on the next client request.
+/**
+ * Force the Auth plugin to invoke the `loadTokens` block again on the next client request.
+ *
+ * @see https://youtrack.jetbrains.com/issue/KTOR-4759/Auth-BearerAuthProvider-caches-result-of-loadToken-until-process-death
+*/
+
+@Suppress("unused")
 fun HttpClient.clearTokens() {
-    try {
-        plugin(Auth).providers
-            .filterIsInstance<BearerAuthProvider>()
-            .first().clearToken()
-    } catch (e: IllegalStateException) {
-        // No-op; plugin not installed
-    }
+    authProvider<BearerAuthProvider>()?.clearToken()
 }

--- a/playground-app/shared/build.gradle.kts
+++ b/playground-app/shared/build.gradle.kts
@@ -1,5 +1,4 @@
 import org.publicvalue.convention.addKspDependencyForAllTargets
-import org.publicvalue.convention.config.configureIosTargets
 
 plugins {
     id("org.publicvalue.convention.android.library")
@@ -44,7 +43,6 @@ kotlin {
         }
 
         val jvmMain by getting {
-            dependsOn(commonMain)
             dependencies {
                 implementation(compose.desktop.common)
                 implementation(libs.kotlin.inject.runtime)

--- a/playground-app/webserver/src/commonMain/kotlin/org/publicvalue/multiplatform/oauth/webserver/Webserver.kt
+++ b/playground-app/webserver/src/commonMain/kotlin/org/publicvalue/multiplatform/oauth/webserver/Webserver.kt
@@ -1,5 +1,6 @@
 package org.publicvalue.multiplatform.oauth.webserver
 
+import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.*
 import io.ktor.server.cio.CIO
@@ -19,24 +20,26 @@ class Webserver(
 ) {
     private var server: CIOApplicationEngine? = null
 
-    suspend fun startAndWaitForRedirect(port: Int): ApplicationRequest? {
-        var call: ApplicationRequest? = null
+    fun startAndWaitForRedirect(port: Int): ApplicationRequest? {
+        var request: ApplicationRequest? = null
         server?.stop()
         embeddedServer(CIO, port = port) {
             routing {
                 get("/redirect") {
-                    this.call.respond(status = HttpStatusCode.OK, Unit)
-                    call = this.call.request
-                    logger.d { "Stopping Webserver" }
-                    server?.stop()
+                    request = call.request
+                    call.respondText(
+                        status = HttpStatusCode.OK,
+                        text = """Authorization redirect successful""".trimIndent(),
+                        contentType = ContentType.parse("text/plain")
+                    )
                 }
             }
         }.apply {
-            server = this
+            server = engine
             logger.d { "Starting Webserver" }
             start(wait = true)
         }
-        return call
+        return request
     }
 
     fun stop() {


### PR DESCRIPTION
Update to Ktor 3.
Fixes #75 .

This will make future releases incompatible with ktor 2. If you still want to user ktor 2, do not upgrade but use kotlin-multiplatform-oidc 0.12.+.
