### PR TITLE
feat: distinguish authentication errors #83

### DIFF
--- a/oidc-appsupport/src/iosMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/PlatformCodeAuthFlow.ios.kt
+++ b/oidc-appsupport/src/iosMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/PlatformCodeAuthFlow.ios.kt
@@ -55,11 +55,8 @@ actual class PlatformCodeAuthFlow(
 
                                 continuation.resume(AuthCodeResponse.success(AuthCodeResult(code = code, state = state)))
                             } else {
-                                if (p2 != null) {
-                                    continuation.resume(AuthCodeResponse.failure<AuthCodeResult>(OpenIdConnectException.AuthenticationFailure(p2.localizedDescription)))
-                                } else {
-                                    continuation.resume(AuthCodeResponse.failure<AuthCodeResult>(OpenIdConnectException.AuthenticationFailure("No message")))
-                                }
+                                // browser closed, no redirect.
+                                continuation.resume(AuthCodeResponse.failure<AuthCodeResult>(OpenIdConnectException.AuthenticationCancelled(p2?.localizedDescription() ?: "Authentication cancelled")))
                             }
                         }
                     }

--- a/oidc-core/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/OpenIdConnectException.kt
+++ b/oidc-core/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/OpenIdConnectException.kt
@@ -14,6 +14,7 @@ sealed class OpenIdConnectException(
 
     data class InvalidUrl(val url: String?, override val cause: Throwable? = null): OpenIdConnectException(message = "Invalid URL: $url", cause = cause)
     data class AuthenticationFailure(override val message: String, override val cause: Throwable? = null): OpenIdConnectException(message = "Authentication failed. $message", cause = cause)
+    data class AuthenticationCancelled(override val message: String = "Authentication cancelled"): OpenIdConnectException(message = "Authentication cancelled", cause = null)
     data class UnsuccessfulTokenRequest(
         override val message: String,
         val statusCode: HttpStatusCode,


### PR DESCRIPTION
This adds an AuthenticationCancelled Exception which is thrown if the user dismisses the login browser window. However, there may be other cases that trigger the same exception. From the lib's POV, we only know that we return to the activity without any data.
