### PR TITLE
Validate nonce before returning the AccessTokenResponse

### DIFF
--- a/oidc-core/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/types/AuthCodeRequest.kt
+++ b/oidc-core/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/types/AuthCodeRequest.kt
@@ -19,3 +19,7 @@ data class AuthCodeRequest(
 fun AuthCodeRequest.validateState(state: String): Boolean {
     return state == this.state
 }
+
+fun AuthCodeRequest.validateNonce(nonce: String): Boolean {
+    return nonce == this.nonce
+}


### PR DESCRIPTION
Checklist for your PR:
- [x] Check if there's any open issue
- [x] Please file your request against the _main_ branch

# Description of your changes
It's difficult to validate the nonce outside the client so I added a check before returning the tokens.

# How has this been tested?
Tested locally

# Is this a (API-) breaking change?
No

