### PR TITLE
Changing POST method to GET method in case of endSession call

### DIFF
--- a/oidc-core/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/DefaultOpenIdConnectClient.kt
+++ b/oidc-core/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/DefaultOpenIdConnectClient.kt
@@ -133,7 +133,7 @@ class DefaultOpenIdConnectClient(
         val endpoint = config.endpoints?.endSessionEndpoint?.trim()
         if (!endpoint.isNullOrEmpty()) {
             val url = URLBuilder(endpoint)
-            val response = httpClient.submitForm {
+            val response = httpClient.get {
                 url(url.build())
                 parameter("id_token_hint", idToken)
                 configure?.invoke(this)


### PR DESCRIPTION
There are 2 reasons why GET should be used. Ktor http client has automatically set followRedirects = true. However it works only for GET methods. In case of POST methods, the plugin HttpRedirect with checkHttpMethod = false should be installed.

    install(HttpRedirect) {
        checkHttpMethod = false // if you want redirects for POST/PUT, not just GET
    }

With this plugin installed the redirect starts to work. However, Microsoft Identity server does not add query parameters to redirect url. The only one right way is to change POST method to GET method. Then redirects works perfectly. Plugin's installation is not needed in this case.

![image](https://github.com/user-attachments/assets/efaee88f-60aa-403b-88c5-4d16d7103b4c)


