### PR TITLE
feat: android: add support for browser priorities

### DIFF
--- a/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/AndroidCodeAuthFlowFactory.kt
+++ b/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/AndroidCodeAuthFlowFactory.kt
@@ -70,9 +70,11 @@ class AndroidCodeAuthFlowFactory(
     }
 
     override fun createAuthFlow(client: OpenIdConnectClient): PlatformCodeAuthFlow {
-        val customTabProviders = context.getCustomTabProviders().map { it.activityInfo.packageName }
-        val presentPreferredProviders = customTabProviderPriority.filter { customTabProviders.contains(it) }
-        val preferredBrowserPackage = presentPreferredProviders.firstOrNull()
+        val preferredBrowserPackage = if (customTabProviderPriority.isNotEmpty()) {
+            val customTabProviders = context.getCustomTabProviders().map { it.activityInfo.packageName }
+            val presentPreferredProviders = customTabProviderPriority.filter { customTabProviders.contains(it) }
+            presentPreferredProviders.firstOrNull()
+        } else null
 
         return PlatformCodeAuthFlow(
             context = context,

--- a/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/HandleRedirectActivity.kt
+++ b/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/HandleRedirectActivity.kt
@@ -18,6 +18,7 @@ internal const val EXTRA_KEY_USEWEBVIEW = "usewebview"
 internal const val EXTRA_KEY_WEBVIEW_EPHEREMAL_SESSION = "webview_epheremal_session"
 internal const val EXTRA_KEY_REDIRECTURL = "redirecturl"
 internal const val EXTRA_KEY_URL = "url"
+internal const val EXTRA_KEY_PACKAGE_NAME = "package"
 
 class HandleRedirectActivity : ComponentActivity() {
 
@@ -113,19 +114,24 @@ class HandleRedirectActivity : ComponentActivity() {
                 // login requested by app
                 // do not navigate to the login page again in this activity instance
                 intent.removeExtra(EXTRA_KEY_URL)
+                // get preferred browser if set
+                val browserPackage = intent.extras?.getString(EXTRA_KEY_PACKAGE_NAME)
+                intent.removeExtra(EXTRA_KEY_PACKAGE_NAME)
                 if (useWebView == true) {
                     showWebView(url, redirectUrl, webViewEpheremalSession ?: false)
                 } else {
-                    launchCustomTabsIntent(url)
+                    launchCustomTabsIntent(url, browserPackage)
                 }
             }
         }
     }
 
-    private fun launchCustomTabsIntent(url: String?) {
+    private fun launchCustomTabsIntent(url: String?, browserPackage: String?) {
         val builder = CustomTabsIntent.Builder()
         builder.configureCustomTabsIntent()
         val intent = builder.build()
+
+        browserPackage?.let { intent.intent.setPackage(it) }
         intent.launchUrl(this, Uri.parse(url))
     }
 

--- a/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/PlatformCodeAuthFlow.android.kt
+++ b/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/PlatformCodeAuthFlow.android.kt
@@ -22,14 +22,16 @@ actual class PlatformCodeAuthFlow(
     contract: ActivityResultLauncherSuspend<Intent, ActivityResult>,
     useWebView: Boolean = false,
     webViewEpheremalSession: Boolean = false,
+    preferredBrowserPackage: String? = null,
     actual override val client: OpenIdConnectClient,
 ) : CodeAuthFlow, EndSessionFlow {
 
     private val webFlow: WebActivityFlow = WebActivityFlow(
-        context,
-        contract,
-        useWebView,
-        webViewEpheremalSession
+        context = context,
+        contract = contract,
+        useWebView = useWebView,
+        webViewEpheremalSession = webViewEpheremalSession,
+        preferredBrowserPackage = preferredBrowserPackage
     )
 
     actual override suspend fun getAuthorizationCode(request: AuthCodeRequest): AuthCodeResponse {

--- a/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/WebActivityFlow.kt
+++ b/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/WebActivityFlow.kt
@@ -10,6 +10,7 @@ internal class WebActivityFlow(
     private val contract: ActivityResultLauncherSuspend<Intent, ActivityResult>,
     private val useWebView: Boolean,
     private val webViewEpheremalSession: Boolean,
+    private val preferredBrowserPackage: String?,
 ) {
     internal suspend fun startWebFlow(requestUrl: Url, redirectUrl: String): ActivityResult {
         val intent = prepareIntent(requestUrl = requestUrl.toString(), redirectUrl = redirectUrl)
@@ -24,6 +25,7 @@ internal class WebActivityFlow(
         )
             .apply {
                 this.putExtra(EXTRA_KEY_URL, requestUrl)
+                this.putExtra(EXTRA_KEY_PACKAGE_NAME, preferredBrowserPackage)
                 if (useWebView) {
                     this.putExtra(EXTRA_KEY_USEWEBVIEW, true)
                     this.putExtra(EXTRA_KEY_REDIRECTURL, redirectUrl)

--- a/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/customtab/Browser.kt
+++ b/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/customtab/Browser.kt
@@ -1,0 +1,19 @@
+package org.publicvalue.multiplatform.oidc.appsupport.customtab
+
+@Suppress("unused")
+object Browser {
+    const val CHROME = "com.android.chrome"
+    const val CHROME_BETA = "com.chrome.beta"
+    const val FIREFOX = "org.mozilla.firefox"
+    const val FIREFOX_BETA = "org.mozilla.firefox_beta"
+    const val FIREFOX_KLAR = "org.mozilla.klar"
+    const val SAMSUNG = "com.sec.android.app.sbrowser"
+    const val BRAVE = "com.brave.browser"
+    const val DUCKDUCKGO = "com.duckduckgo.mobile.android"
+    const val ECOSIA = "com.ecosia.android"
+    const val EDGE = "com.microsoft.emmx"
+    const val VIVALDI = "com.vivaldi.browser"
+    const val YANDEX = "com.yandex.browser"
+    const val TOR = "org.torproject.torbrowser"
+}
+

--- a/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/customtab/Context+getCustomTabProviders.kt
+++ b/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/customtab/Context+getCustomTabProviders.kt
@@ -1,0 +1,23 @@
+package org.publicvalue.multiplatform.oidc.appsupport.customtab
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.content.pm.ResolveInfo
+import androidx.core.net.toUri
+
+private val ACTION_CUSTOM_TABS_CONNECTION = "android.support.customtabs.action.CustomTabsService"
+
+fun Context.getCustomTabProviders(): List<ResolveInfo> {
+    val activityIntent = Intent(Intent.ACTION_VIEW, "http://www.example.com".toUri())
+
+    // Get all apps that can handle VIEW intents.
+    val resolvedActivityList = packageManager.queryIntentActivities(activityIntent, PackageManager.MATCH_ALL)
+    val serviceIntent = Intent()
+    serviceIntent.setAction(ACTION_CUSTOM_TABS_CONNECTION)
+    val customTabProviders = resolvedActivityList.filter {
+        serviceIntent.setPackage(it.activityInfo.packageName)
+        packageManager.resolveService(serviceIntent, 0) != null
+    }
+    return customTabProviders
+}

--- a/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/customtab/Context+getCustomTabProviders.kt
+++ b/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/customtab/Context+getCustomTabProviders.kt
@@ -4,15 +4,20 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.pm.ResolveInfo
+import android.os.Build
 import androidx.core.net.toUri
 
 private val ACTION_CUSTOM_TABS_CONNECTION = "android.support.customtabs.action.CustomTabsService"
 
-fun Context.getCustomTabProviders(): List<ResolveInfo> {
+internal fun Context.getCustomTabProviders(): List<ResolveInfo> {
     val activityIntent = Intent(Intent.ACTION_VIEW, "http://www.example.com".toUri())
 
     // Get all apps that can handle VIEW intents.
-    val resolvedActivityList = packageManager.queryIntentActivities(activityIntent, PackageManager.MATCH_ALL)
+    val resolvedActivityList = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        packageManager.queryIntentActivities(activityIntent, PackageManager.MATCH_ALL)
+    } else {
+        packageManager.queryIntentActivities(activityIntent, 0)
+    }
     val serviceIntent = Intent()
     serviceIntent.setAction(ACTION_CUSTOM_TABS_CONNECTION)
     val customTabProviders = resolvedActivityList.filter {


### PR DESCRIPTION
If required, one can set the customTabProviderPriority parameter when building the AndroidCodeAuthFlowFactory. Makes it possible to select another installed browser for authentication instead of the default browser.

Hi, thanks for contributing to this project!

Checklist for your PR:
- [ ] Check if there's any open issue
- [ ] Please file your request against the _main_ branch

# Description of your changes
Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

# How has this been tested?

# Is this a (API-) breaking change?

