### PR TITLE
Update executeTokenRequest to propageate exception up to caller

### DIFF
--- a/oidc-core/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/DefaultOpenIdConnectClient.kt
+++ b/oidc-core/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/DefaultOpenIdConnectClient.kt
@@ -243,23 +243,24 @@ class DefaultOpenIdConnectClient(
                 val accessTokenResponse: AccessTokenResponse = response.call.body()
                 accessTokenResponse
             } catch (e: NoTransformationFoundException) {
-                throw response.toOpenIdConnectException()
+                throw response.toOpenIdConnectException(e)
             } catch (e: JsonConvertException) {
-                throw response.toOpenIdConnectException()
+                throw response.toOpenIdConnectException(e)
             }
         } else {
             throw response.toOpenIdConnectException()
         }
     }
 
-    private suspend fun HttpResponse.toOpenIdConnectException(): OpenIdConnectException.UnsuccessfulTokenRequest {
+    private suspend fun HttpResponse.toOpenIdConnectException(cause: Throwable? = null): OpenIdConnectException.UnsuccessfulTokenRequest {
         val errorResponse = call.errorBody()
         val body = call.body<String>().decodeURLQueryComponent(plusIsSpace = true)
         return OpenIdConnectException.UnsuccessfulTokenRequest(
             message = "Exchange token failed: ${status.value} ${errorResponse?.error_description ?: errorResponse?.error}",
             statusCode = status,
             body = body,
-            errorResponse = errorResponse
+            errorResponse = errorResponse,
+            cause = cause
         )
     }
 }


### PR DESCRIPTION
# Description of your changes
When calling `executeTokenRequest` a `OpenIdConnectException.UnsuccessfulTokenRequest` is returned if an exception is throw, however the information about the original exception is lost. This change resolves that by adding the throwable to the response

# How has this been tested?
Local testing

# Is this a (API-) breaking change?
No
