### PR TITLE
Implement ephemeral custom tabs

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-compileSdk = "35"
-targetSdk = "35"
+compileSdk = "36"
+targetSdk = "36"
 minSdk = "21"
 
 jvmTarget = "17"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,7 +57,7 @@ material-icons = "1.7.3"
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidxActivity" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidxAppCompat" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
-androidx-browser = { module = "androidx.browser:browser", version = "1.8.0" }
+androidx-browser = { module = "androidx.browser:browser", version = "1.9.0-rc01" }
 androidx-security-crypto-ktx = { module = "androidx.security:security-crypto-ktx", version.ref = "securityCryptoKtx" }
 androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "securityCryptoKtx" }
 
@@ -84,7 +84,7 @@ ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-client-auth = { module = "io.ktor:ktor-client-auth", version.ref = "ktor" }
-ktor-client-contentnegotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor"}
+ktor-client-contentnegotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-client-serialization = { module = "io.ktor:ktor-client-serialization", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
@@ -97,7 +97,7 @@ ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor"
 
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 assertk = { module = "com.willowtreeapps.assertk:assertk", version.ref = "assertk" }
-material-icons-core = { module = "org.jetbrains.compose.material:material-icons-core", version.ref = "material-icons"}
+material-icons-core = { module = "org.jetbrains.compose.material:material-icons-core", version.ref = "material-icons" }
 
 # Build logic dependencies
 android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
@@ -124,10 +124,10 @@ android-library = { id = "com.android.library", version.ref = "agp" }
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
-kmp = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin"}
+kmp = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexus-publish-plugin"}
+nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexus-publish-plugin" }
 multiplatform-swiftpackage = { id = "io.github.luca992.multiplatform-swiftpackage", version.ref = "multiplatform-swiftpackage" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 swiftklib = { id = "io.github.ttypic.swiftklib", version.ref = "swiftklib" }

--- a/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/AndroidCodeAuthFlowFactory.kt
+++ b/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/AndroidCodeAuthFlowFactory.kt
@@ -35,7 +35,7 @@ class AndroidCodeAuthFlowFactory(
     /**
      * If `true`, the authorization session will be ephemeral:
      * cookies, cache, and other session data will be cleared before starting
-     * the flow in both WebView and Custom Tabs.
+     * the flow in both WebView and Custom Tabs (if supported).
      */
     private val ephemeralSession: Boolean = false,
     /** preferred custom tab providers, list of package names in order of priority. Check [Browser][org.publicvalue.multiplatform.oidc.appsupport.customtab.Browser] for example values. **/

--- a/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/AndroidCodeAuthFlowFactory.kt
+++ b/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/AndroidCodeAuthFlowFactory.kt
@@ -23,9 +23,20 @@ import org.publicvalue.multiplatform.oidc.flows.EndSessionFlow
  */
 @Suppress("unused")
 class AndroidCodeAuthFlowFactory(
-    /** If true, uses an embedded WebView instead of Chrome CustomTab (not recommended) **/
+    /**
+     * If `true`, an embedded WebView is used for the authorization flow.
+     * This is generally **not recommended** due to security and UX concerns.
+     *
+     * If `false` (default), Chrome Custom Tabs are preferred (if available),
+     * falling back to a WebView only if no suitable browser is found.
+     */
     private val useWebView: Boolean = false,
-    /** Clear cache and cookies in WebView or Chrome CustomTab. **/
+
+    /**
+     * If `true`, the authorization session will be ephemeral:
+     * cookies, cache, and other session data will be cleared before starting
+     * the flow in both WebView and Custom Tabs.
+     */
     private val ephemeralSession: Boolean = false,
     /** preferred custom tab providers, list of package names in order of priority. Check [Browser][org.publicvalue.multiplatform.oidc.appsupport.customtab.Browser] for example values. **/
     private val customTabProviderPriority: List<String> = listOf()

--- a/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/AndroidCodeAuthFlowFactory.kt
+++ b/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/AndroidCodeAuthFlowFactory.kt
@@ -25,8 +25,8 @@ import org.publicvalue.multiplatform.oidc.flows.EndSessionFlow
 class AndroidCodeAuthFlowFactory(
     /** If true, uses an embedded WebView instead of Chrome CustomTab (not recommended) **/
     private val useWebView: Boolean = false,
-    /** Clear cache and cookies in WebView **/
-    private val webViewEpheremalSession: Boolean = false,
+    /** Clear cache and cookies in WebView or Chrome CustomTab. **/
+    private val ephemeralSession: Boolean = false,
     /** preferred custom tab providers, list of package names in order of priority. Check [Browser][org.publicvalue.multiplatform.oidc.appsupport.customtab.Browser] for example values. **/
     private val customTabProviderPriority: List<String> = listOf()
 ): CodeAuthFlowFactory {
@@ -81,7 +81,7 @@ class AndroidCodeAuthFlowFactory(
             contract = activityResultLauncher,
             client = client,
             useWebView = useWebView,
-            webViewEpheremalSession = webViewEpheremalSession,
+            ephemeralSession = ephemeralSession,
             preferredBrowserPackage = preferredBrowserPackage
         )
     }

--- a/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/AndroidCodeAuthFlowFactory.kt
+++ b/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/AndroidCodeAuthFlowFactory.kt
@@ -81,11 +81,12 @@ class AndroidCodeAuthFlowFactory(
     }
 
     override fun createAuthFlow(client: OpenIdConnectClient): PlatformCodeAuthFlow {
+        val customTabProviders = context.getCustomTabProviders().map { it.activityInfo.packageName }
         val preferredBrowserPackage = if (customTabProviderPriority.isNotEmpty()) {
-            val customTabProviders = context.getCustomTabProviders().map { it.activityInfo.packageName }
-            val presentPreferredProviders = customTabProviderPriority.filter { customTabProviders.contains(it) }
+            val presentPreferredProviders =
+                customTabProviderPriority.filter { customTabProviders.contains(it) }
             presentPreferredProviders.firstOrNull()
-        } else null
+        } else customTabProviders.firstOrNull()
 
         return PlatformCodeAuthFlow(
             context = context,

--- a/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/HandleRedirectActivity.kt
+++ b/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/HandleRedirectActivity.kt
@@ -17,7 +17,6 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updateLayoutParams
 import org.publicvalue.multiplatform.oidc.ExperimentalOpenIdConnect
-import org.publicvalue.multiplatform.oidc.appsupport.customtab.getCustomTabProviders
 
 internal const val EXTRA_KEY_USEWEBVIEW = "usewebview"
 internal const val EXTRA_KEY_EPHEMERAL_SESSION = "ephemeral_session"
@@ -157,13 +156,9 @@ class HandleRedirectActivity : ComponentActivity() {
         val builder = CustomTabsIntent.Builder()
         builder.configureCustomTabsIntent()
 
-        // Get preferred browser or first available browser for custom tabs
-        val browserPackage = preferredBrowserPackage
-            ?: getCustomTabProviders().firstOrNull()?.activityInfo?.packageName
-
-        if (browserPackage != null) {
+        if (preferredBrowserPackage != null) {
             // Enable ephemeral browsing if supported
-            if (CustomTabsClient.isEphemeralBrowsingSupported(this, browserPackage)) {
+            if (CustomTabsClient.isEphemeralBrowsingSupported(this, preferredBrowserPackage)) {
                 builder.setEphemeralBrowsingEnabled(ephemeralSession ?: false)
             }
         } else {
@@ -175,7 +170,7 @@ class HandleRedirectActivity : ComponentActivity() {
 
         val intent = builder.build()
 
-        preferredBrowserPackage?.let { intent.intent.setPackage(it) }
+        preferredBrowserPackage.let { intent.intent.setPackage(it) }
         intent.launchUrl(this, url.toUri())
     }
 

--- a/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/HandleRedirectActivity.kt
+++ b/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/HandleRedirectActivity.kt
@@ -161,7 +161,6 @@ class HandleRedirectActivity : ComponentActivity() {
         val browserPackage = preferredBrowserPackage
             ?: getCustomTabProviders().firstOrNull()?.activityInfo?.packageName
 
-        CookieManager.getInstance().removeAllCookies(null)
         if (browserPackage != null) {
             // Enable ephemeral browsing if supported
             if (CustomTabsClient.isEphemeralBrowsingSupported(this, browserPackage)) {

--- a/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/HandleRedirectActivity.kt
+++ b/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/HandleRedirectActivity.kt
@@ -1,7 +1,6 @@
 package org.publicvalue.multiplatform.oidc.appsupport
 
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.view.ViewGroup
 import android.webkit.CookieManager
@@ -11,14 +10,17 @@ import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.activity.ComponentActivity
+import androidx.browser.customtabs.CustomTabsClient
 import androidx.browser.customtabs.CustomTabsIntent
+import androidx.core.net.toUri
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updateLayoutParams
 import org.publicvalue.multiplatform.oidc.ExperimentalOpenIdConnect
+import org.publicvalue.multiplatform.oidc.appsupport.customtab.getCustomTabProviders
 
 internal const val EXTRA_KEY_USEWEBVIEW = "usewebview"
-internal const val EXTRA_KEY_WEBVIEW_EPHEREMAL_SESSION = "webview_epheremal_session"
+internal const val EXTRA_KEY_EPHEMERAL_SESSION = "ephemeral_session"
 internal const val EXTRA_KEY_REDIRECTURL = "redirecturl"
 internal const val EXTRA_KEY_URL = "url"
 internal const val EXTRA_KEY_PACKAGE_NAME = "package"
@@ -107,7 +109,7 @@ class HandleRedirectActivity : ComponentActivity() {
     override fun onResume() {
         super.onResume()
         val useWebView = intent.extras?.getBoolean(EXTRA_KEY_USEWEBVIEW)
-        val webViewEpheremalSession = intent.extras?.getBoolean(EXTRA_KEY_WEBVIEW_EPHEREMAL_SESSION)
+        val ephemeralSession = intent.extras?.getBoolean(EXTRA_KEY_EPHEMERAL_SESSION)
         val url = intent.extras?.getString(EXTRA_KEY_URL)
         val redirectUrl = intent.extras?.getString(EXTRA_KEY_REDIRECTURL)
 
@@ -129,24 +131,53 @@ class HandleRedirectActivity : ComponentActivity() {
                 // do not navigate to the login page again in this activity instance
                 intent.removeExtra(EXTRA_KEY_URL)
                 // get preferred browser if set
-                val browserPackage = intent.extras?.getString(EXTRA_KEY_PACKAGE_NAME)
+                val preferredBrowserPackage = intent.extras?.getString(EXTRA_KEY_PACKAGE_NAME)
                 intent.removeExtra(EXTRA_KEY_PACKAGE_NAME)
                 if (useWebView == true) {
-                    showWebView(url, redirectUrl, webViewEpheremalSession ?: false)
+                    showWebView(url, redirectUrl, ephemeralSession ?: false)
                 } else {
-                    launchCustomTabsIntent(url, browserPackage)
+                    launchCustomTabsIntent(
+                        url,
+                        redirectUrl,
+                        preferredBrowserPackage,
+                        ephemeralSession
+                    )
                 }
             }
         }
     }
 
-    private fun launchCustomTabsIntent(url: String?, browserPackage: String?) {
+    @OptIn(ExperimentalOpenIdConnect::class)
+    private fun launchCustomTabsIntent(
+        url: String,
+        redirectUrl: String?,
+        preferredBrowserPackage: String?,
+        ephemeralSession: Boolean?
+    ) {
         val builder = CustomTabsIntent.Builder()
         builder.configureCustomTabsIntent()
+
+        // Get preferred browser or first available browser for custom tabs
+        val browserPackage = preferredBrowserPackage
+            ?: getCustomTabProviders().firstOrNull()?.activityInfo?.packageName
+
+        CookieManager.getInstance().removeAllCookies(null)
+        if (browserPackage != null) {
+            // Enable ephemeral browsing if supported
+            if (CustomTabsClient.isEphemeralBrowsingSupported(this, browserPackage)) {
+                builder.setEphemeralBrowsingEnabled(ephemeralSession ?: false)
+            }
+        } else {
+            // If custom tabs are not available, fallback to WebView
+            showWebView(url, redirectUrl, ephemeralSession ?: false)
+            return
+        }
+
+
         val intent = builder.build()
 
-        browserPackage?.let { intent.intent.setPackage(it) }
-        intent.launchUrl(this, Uri.parse(url))
+        preferredBrowserPackage?.let { intent.intent.setPackage(it) }
+        intent.launchUrl(this, url.toUri())
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/PlatformCodeAuthFlow.android.kt
+++ b/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/PlatformCodeAuthFlow.android.kt
@@ -21,7 +21,7 @@ actual class PlatformCodeAuthFlow(
     context: Context,
     contract: ActivityResultLauncherSuspend<Intent, ActivityResult>,
     useWebView: Boolean = false,
-    webViewEpheremalSession: Boolean = false,
+    ephemeralSession: Boolean = false,
     preferredBrowserPackage: String? = null,
     actual override val client: OpenIdConnectClient,
 ) : CodeAuthFlow, EndSessionFlow {
@@ -30,7 +30,7 @@ actual class PlatformCodeAuthFlow(
         context = context,
         contract = contract,
         useWebView = useWebView,
-        webViewEpheremalSession = webViewEpheremalSession,
+        ephemeralSession = ephemeralSession,
         preferredBrowserPackage = preferredBrowserPackage
     )
 

--- a/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/WebActivityFlow.kt
+++ b/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/WebActivityFlow.kt
@@ -9,7 +9,7 @@ internal class WebActivityFlow(
     private val context: Context,
     private val contract: ActivityResultLauncherSuspend<Intent, ActivityResult>,
     private val useWebView: Boolean,
-    private val webViewEpheremalSession: Boolean,
+    private val ephemeralSession: Boolean,
     private val preferredBrowserPackage: String?,
 ) {
     internal suspend fun startWebFlow(requestUrl: Url, redirectUrl: String): ActivityResult {
@@ -26,10 +26,10 @@ internal class WebActivityFlow(
             .apply {
                 this.putExtra(EXTRA_KEY_URL, requestUrl)
                 this.putExtra(EXTRA_KEY_PACKAGE_NAME, preferredBrowserPackage)
+                this.putExtra(EXTRA_KEY_EPHEMERAL_SESSION, ephemeralSession)
                 if (useWebView) {
                     this.putExtra(EXTRA_KEY_USEWEBVIEW, true)
                     this.putExtra(EXTRA_KEY_REDIRECTURL, redirectUrl)
-                    this.putExtra(EXTRA_KEY_WEBVIEW_EPHEREMAL_SESSION, webViewEpheremalSession)
                 }
             }
         return intent


### PR DESCRIPTION
## Summary

This PR implements the enhancement suggested in [#98](https://github.com/kalinjul/kotlin-multiplatform-oidc/issues/98), improving ephemeral session support for Custom Tabs on Android.

## Changes

- Renamed `webViewEpheremalSession` to `ephemeralSession` in `AndroidCodeAuthFlowFactory`
- Updated `androidx.browser` to `1.9.0-rc01`
- Moved `EXTRA_KEY_EPHEMERAL_SESSION` outside the `useWebView` check
- Utilized `CustomTabsIntent.Builder.setEphemeralBrowsingEnabled(true)`
- Updated inline comments

## Testing

Compiled the support JAR and tested in the following scenarios:

1. **Old Chrome version** – Custom Tabs launch without ephemeral session (as expected)
2. **Latest Chrome, Brave, Firefox, Samsung Internet** – Custom Tabs launch with ephemeral session enabled
3. **No Custom Tabs support** – Fallback to WebView

## Breaking Change

- **Renamed AndroidCodeAuthFlowFactory constructor param**:  
  `webViewEpheremalSession` → `ephemeralSession`  
  **Migration**:  
  Replace  
  ```kotlin
  AndroidCodeAuthFlowFactory(..., webViewEpheremalSession = true)
  ```
  With  
  ```kotlin
  AndroidCodeAuthFlowFactory(..., ephemeralSession = true)
  ```

> **Note:** `androidx.browser:browser:1.9.0-rc01` is a release candidate. It should be updated to the stable version once available. Since the `setEphemeralBrowsingEnabled` API is unlikely to change, only a version bump should be necessary when upgrading.
