### PR TITLE
Handle ActivityNotFoundException by falling back to WebView

### DIFF
--- a/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/HandleRedirectActivity.kt
+++ b/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/HandleRedirectActivity.kt
@@ -1,5 +1,6 @@
 package org.publicvalue.multiplatform.oidc.appsupport
 
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.os.Bundle
 import android.view.ViewGroup
@@ -171,7 +172,12 @@ class HandleRedirectActivity : ComponentActivity() {
         val intent = builder.build()
 
         preferredBrowserPackage.let { intent.intent.setPackage(it) }
-        intent.launchUrl(this, url.toUri())
+        try {
+            intent.launchUrl(this, url.toUri())
+        } catch (_: ActivityNotFoundException) {
+            // If there is no browser activity available, fallback to WebView
+            showWebView(url, redirectUrl, ephemeralSession ?: false)
+        }
     }
 
     override fun onNewIntent(intent: Intent) {


### PR DESCRIPTION
On internal production devices in Android Work mode we saw the following crash, hinting at an unavailability of a system default browser in Android Work:

```
Fatal Exception: java.lang.RuntimeException: Unable to resume activity {our.app/org.publicvalue.multiplatform.oidc.appsupport.HandleRedirectActivity}: android.content.ActivityNotFoundException: No Activity found to handle Intent { act=android.intent.action.VIEW dat=https://our.oauth.url/... (has extras) }
       at android.app.ActivityThread.performResumeActivity(ActivityThread.java:5378)
       at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:5444)
       at android.app.servertransaction.ResumeActivityItem.execute(ResumeActivityItem.java:54)
       at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:45)
       at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176)
       at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2574)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loopOnce(Looper.java:226)
       at android.os.Looper.loop(Looper.java:313)
       at android.app.ActivityThread.main(ActivityThread.java:8762)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:604)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1067)
Caused by android.content.ActivityNotFoundException: No Activity found to handle Intent { act=android.intent.action.VIEW dat=https://our.oauth.url/... (has extras) }
       at android.app.Instrumentation.checkStartActivityResult(Instrumentation.java:2174)
       at android.app.Instrumentation.execStartActivity(Instrumentation.java:1805)
       at android.app.Activity.startActivityForResult(Activity.java:5596)
       at androidx.activity.ComponentActivity.startActivityForResult(ComponentActivity.kt:675)
       at android.app.Activity.startActivityForResult(Activity.java:5554)
       at androidx.activity.ComponentActivity.startActivityForResult(ComponentActivity.kt:660)
       at android.app.Activity.startActivity(Activity.java:6052)
       at androidx.core.content.ContextCompat.startActivity(ContextCompat.java:297)
       at androidx.browser.customtabs.CustomTabsIntent.launchUrl(CustomTabsIntent.java:662)
       at org.publicvalue.multiplatform.oidc.appsupport.HandleRedirectActivity.launchCustomTabsIntent(HandleRedirectActivity.kt:129)
       at org.publicvalue.multiplatform.oidc.appsupport.HandleRedirectActivity.onResume(HandleRedirectActivity.kt:119)
       at android.app.Instrumentation.callActivityOnResume(Instrumentation.java:1531)
       at android.app.Activity.performResume(Activity.java:8734)
       at android.app.ActivityThread.performResumeActivity(ActivityThread.java:5351)
       at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:5444)
       at android.app.servertransaction.ResumeActivityItem.execute(ResumeActivityItem.java:54)
       at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:45)
       at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176)
       at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2574)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loopOnce(Looper.java:226)
       at android.os.Looper.loop(Looper.java:313)
       at android.app.ActivityThread.main(ActivityThread.java:8762)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:604)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1067)
```

This PR addresses this crash by falling back to the webview when said exception occurs. 