### PR TITLE
Fixes #131 By no longer allowing irrelevant messages to close the callback listener

### DIFF
--- a/oidc-appsupport/src/wasmJsMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/WebPopupFlow.kt
+++ b/oidc-appsupport/src/wasmJsMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/WebPopupFlow.kt
@@ -5,8 +5,8 @@ import kotlinx.browser.window
 import kotlinx.serialization.json.Json
 import org.publicvalue.multiplatform.oidc.ExperimentalOpenIdConnect
 import org.publicvalue.multiplatform.oidc.OpenIdConnectException.TechnicalFailure
-import org.w3c.dom.AddEventListenerOptions
 import org.w3c.dom.MessageEvent
+import org.w3c.dom.Window
 import org.w3c.dom.events.Event
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
@@ -19,13 +19,12 @@ internal class WebPopupFlow(
 ) {
     internal suspend fun startWebFlow(requestUrl: Url): Url {
         return suspendCoroutine<Url> { continuation ->
-            val popup = window.open(requestUrl.toString(), windowTarget, windowFeatures)
+            println("${WebPopupFlow::class.simpleName} - New Flow")
 
-            if (popup == null) {
-                throw TechnicalFailure("No popup opened", null)
-            }
+            lateinit var popup: Window
+            lateinit var messageHandler: (Event) -> Unit
 
-            val messageHandler: (Event) -> Unit = { event ->
+            messageHandler = { event ->
                 if (event is MessageEvent) {
 
                     if (event.origin != redirectOrigin)
@@ -35,14 +34,19 @@ internal class WebPopupFlow(
                         val urlString: String = Json.decodeFromString(getEventData(event))
                         val url = Url(urlString)
                         continuation.resume(url)
+
+                        window.removeEventListener("message", messageHandler)
+                    } else {
+                        // Log a warning and stay registered
+                        println("${WebPopupFlow::class.simpleName} skipping message from unknown source: ${event.source}")
                     }
                 }
             }
 
-            window.addEventListener("message", messageHandler, AddEventListenerOptions(
-                    once = true
-                )
-            )
+            window.addEventListener("message", messageHandler)
+
+            popup = window.open(requestUrl.toString(), windowTarget, windowFeatures)
+                ?: throw TechnicalFailure("Could not open popup", null)
         }
     }
 


### PR DESCRIPTION
See #131 

My WASM/JS integration was failing to work due to some irrelevant other message being seen by the callback listener first.
Since the listener was configured to listen 'once' only; the spurious message caused it to stop listening before the true auth callback arrived, breaking the flow.

This change:
- Removes the 'once only' listen option, replacing it by explicit removal after the expected callback is received.
- Registers the callback listener before the popup is opened; removing a race condition between registration and receipt, however small.

# How has this been tested?
Publishing to `mavenLocal` (locally suppressing the signing code) and recompiling my App against modified version.

# Is this a (API-) breaking change?
No.

