### PR TITLE
Code simplification without swiftklib

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ minSdk = "21"
 
 jvmTarget = "17"
 # https://developer.android.com/build/releases/gradle-plugin#compatibility
-agp = "8.9.3"
+agp = "8.10.1"
 
 #https://github.com/JetBrains/compose-multiplatform
 compose-multiplatform = "1.8.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ minSdk = "21"
 
 jvmTarget = "17"
 # https://developer.android.com/build/releases/gradle-plugin#compatibility
-agp = "8.10.1"
+agp = "8.9.3"
 
 #https://github.com/JetBrains/compose-multiplatform
 compose-multiplatform = "1.8.2"
@@ -62,6 +62,7 @@ androidx-datastore = { module = "androidx.datastore:datastore-preferences", vers
 androidx-browser = { module = "androidx.browser:browser", version = "1.9.0-rc01" }
 androidx-security-crypto-ktx = { module = "androidx.security:security-crypto-ktx", version.ref = "securityCryptoKtx" }
 androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "securityCryptoKtx" }
+material-icons-core = { module = "org.jetbrains.compose.material:material-icons-core", version.ref = "material-icons" }
 
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
@@ -99,7 +100,6 @@ ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor"
 
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 assertk = { module = "com.willowtreeapps.assertk:assertk", version.ref = "assertk" }
-material-icons-core = { module = "org.jetbrains.compose.material:material-icons-core", version.ref = "material-icons" }
 
 # Build logic dependencies
 android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
@@ -132,4 +132,3 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexus-publish-plugin" }
 multiplatform-swiftpackage = { id = "io.github.luca992.multiplatform-swiftpackage", version.ref = "multiplatform-swiftpackage" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
-swiftklib = { id = "io.github.ttypic.swiftklib", version.ref = "swiftklib" }

--- a/oidc-crypto/build.gradle.kts
+++ b/oidc-crypto/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
     id("org.publicvalue.convention.kotlin.multiplatform")
     id("org.publicvalue.convention.kotlin.multiplatform.mobile")
     alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.swiftklib)
     id("org.publicvalue.convention.centralPublish")
 }
 
@@ -46,29 +45,5 @@ kotlin {
         }
     }
 
-    listOf(
-        iosX64(),
-        iosArm64(),
-        iosSimulatorArm64(),
-    ).forEach {
-        it.compilations {
-            val main by getting {
-                cinterops {
-                    create("KCrypto")
-                }
-            }
-        }
-    }
-
     exportKdoc()
-}
-
-if (DefaultNativePlatform.getCurrentOperatingSystem().isMacOsX) {
-    swiftklib {
-        create("KCrypto") {
-            this.minIos = 15
-            path = file("native/KCrypto")
-            packageName("org.publicvalue.multiplatform.oidc.util")
-        }
-    }
 }

--- a/oidc-crypto/src/iosMain/kotlin/org/publicvalue/multiplatform/oidc/Crypto.ios.kt
+++ b/oidc-crypto/src/iosMain/kotlin/org/publicvalue/multiplatform/oidc/Crypto.ios.kt
@@ -2,17 +2,12 @@ package org.publicvalue.multiplatform.oidc
 
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
-import kotlinx.cinterop.allocArrayOf
 import kotlinx.cinterop.convert
-import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.usePinned
 import platform.CoreCrypto.CC_SHA256
-import platform.Foundation.NSData
-import platform.Foundation.create
 import platform.Security.SecRandomCopyBytes
 import platform.Security.errSecSuccess
 import platform.Security.kSecRandomDefault
-import platform.posix.memcpy
 
 @OptIn(ExperimentalForeignApi::class)
 actual fun secureRandomBytes(size: Int): ByteArray {


### PR DESCRIPTION
# Description of your changes
I've removed the swiftklib. I think it's better to avoid unnecessary dependency, as it is possible.  

# How has this been tested?
 The operation tested of ios using an example. The authorization flow is working correctly 

# Is this a (API-) breaking change?
Using native api for s256 and secureRandomBytes

