### PR TITLE
Reduce iOS UI freeze during first time logging in after app built by Xcode; improve browser session lifecycle

### DIFF
--- a/oidc-appsupport/src/iosMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/IosCodeAuthFlowFactory.kt
+++ b/oidc-appsupport/src/iosMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/IosCodeAuthFlowFactory.kt
@@ -1,6 +1,5 @@
 package org.publicvalue.multiplatform.oidc.appsupport
 
-import kotlinx.coroutines.runBlocking
 import org.publicvalue.multiplatform.oidc.OpenIdConnectClient
 import org.publicvalue.multiplatform.oidc.flows.EndSessionFlow
 import org.publicvalue.multiplatform.oidc.preferences.PREFERENCES_FILENAME
@@ -15,11 +14,14 @@ class IosCodeAuthFlowFactory(
     private val ephemeralBrowserSession: Boolean = false,
     /** factory used to create preferences to save session information during login process. **/
     private val preferencesFactory: PreferencesFactory = PreferencesFactory()
-): CodeAuthFlowFactory {
-    private val preferences = runBlocking { preferencesFactory.getOrCreate(PREFERENCES_FILENAME) }
+) : CodeAuthFlowFactory {
+    private val preferences = preferencesFactory.create(PREFERENCES_FILENAME)
 
     // constructor for swift-only library
-    constructor(ephemeralBrowserSession: Boolean) : this(ephemeralBrowserSession, preferencesFactory = PreferencesFactory())
+    constructor(ephemeralBrowserSession: Boolean) : this(
+        ephemeralBrowserSession,
+        preferencesFactory = PreferencesFactory()
+    )
 
     override fun createAuthFlow(client: OpenIdConnectClient): PlatformCodeAuthFlow {
         return PlatformCodeAuthFlow(

--- a/oidc-appsupport/src/iosMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/PlatformCodeAuthFlow.ios.kt
+++ b/oidc-appsupport/src/iosMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/PlatformCodeAuthFlow.ios.kt
@@ -48,6 +48,8 @@ actual class PlatformCodeAuthFlow internal constructor(
 
 class PresentationContext : NSObject(), ASWebAuthenticationPresentationContextProvidingProtocol {
     override fun presentationAnchorForWebAuthenticationSession(session: ASWebAuthenticationSession): ASPresentationAnchor {
+        // Locate the active UIWindow to correctly anchor the browser session on top of the app.
+        // If no window is found, create a new ASPresentationAnchor.
         val window = UIApplication.sharedApplication.connectedScenes
             .mapNotNull { it as? UIWindowScene }
             .firstOrNull { it.activationState == UISceneActivationStateForegroundActive }

--- a/oidc-preferences/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/preferences/PreferencesFactory.kt
+++ b/oidc-preferences/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/preferences/PreferencesFactory.kt
@@ -8,6 +8,7 @@ abstract class PreferencesSingletonFactory {
     companion object {
         @JvmStatic
         protected val mutex = Mutex()
+
         @JvmStatic
         @kotlin.concurrent.Volatile
         protected var INSTANCE: Preferences? = null
@@ -23,7 +24,7 @@ abstract class PreferencesSingletonFactory {
         }
     }
 
-    protected abstract fun create(filename: String): Preferences
+    abstract fun create(filename: String): Preferences
 }
 
 expect class PreferencesFactory


### PR DESCRIPTION
Hi, thanks for contributing to this project!

Checklist for your PR:
- [X] Check if there's any open issue
- [X] Please file your request against the _main_ branch

# Description of your changes
Context: https://github.com/kalinjul/kotlin-multiplatform-oidc/issues/157

- `IosCodeAuthFlowFactory.kt`: Removed runBlocking from the preferences property and switched to direct instantiation via `preferencesFactory.create()` to avoid blocking the main thread during object creation.
- `WebSessionFlow.kt`: Removed runBlocking lines, and made presentationContext a class property to ensure a strong reference is held.
- Updated `PresentationContext` to use the actual app window on screen instead of a detached anchor (with fallback to detached if needed).

# How has this been tested?

I'm testing this on an app I'm currently building; the goal being to login with Keycloak OIDC. The amount of time which the app's UI is blocked while waiting to open the webSessionFlow has been greatly reduced.

# Is this a (API-) breaking change?
No.

Note however, that I relaxed `PreferencesSingletonFactory.create()`'s visibility from protected to public. That said, this won't change the API from a consumer's perspective.