### PR TITLE
fix: JWT parsing should use base64url decoding

### DIFF
--- a/oidc-core/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/types/Jwt.kt
+++ b/oidc-core/src/commonMain/kotlin/org/publicvalue/multiplatform/oidc/types/Jwt.kt
@@ -34,7 +34,7 @@ data class Jwt(
     val signature: String?
 ) {
     companion object {
-        private val base64 by lazy { Base64.withPadding(Base64.PaddingOption.ABSENT) }
+        private val base64 by lazy { Base64.UrlSafe.withPadding(Base64.PaddingOption.ABSENT) }
 
         /**
          * JWTs are either encoded using JWS Compact Serialization (signed, 3 parts) or JWE Compact Serialization (encrypted, 5 parts).

--- a/oidc-core/src/commonTest/kotlin/org/publicvalue/multiplatform/oidc/JwtTest.kt
+++ b/oidc-core/src/commonTest/kotlin/org/publicvalue/multiplatform/oidc/JwtTest.kt
@@ -78,4 +78,12 @@ class JwtTest {
         assertThat(identitiesMap["userId"]).isEqualTo("amzn1.account.EXAMPLE")
         assertThat(identitiesMap["providerName"]).isEqualTo("LoginWithAmazon")
     }
+
+    @Test
+    fun urlEncodedChar() {
+        // this token contains _ and - chars, which are base64url encoded
+        val idToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaWF0IjoxNTE2MjM5MDIyLCJmaWVsZCI6Im8_PHA-In0.xqkIJiRfQJX_WHso5O5AAEbz3XM0JJd_uVX48tzh9j0"
+        val jwt = Jwt.parse(idToken)
+        assertThat(jwt.payload.additionalClaims["field"]).isEqualTo("o?<p>")
+    }
 }


### PR DESCRIPTION
fixes #166 