### PR TITLE
Feature/desktop keyring tokenstore

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,6 +55,8 @@ russhwolf = "1.3.0"
 kotlincrypto-hash = "0.8.0"
 material-icons = "1.7.3"
 
+java-keyring = "1.0.4"
+
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidxActivity" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidxAppCompat" }
@@ -121,6 +123,8 @@ russhwolf-multiplatformsettings = { module = "com.russhwolf:multiplatform-settin
 
 kotlincrypto-hash-bom = { module = "org.kotlincrypto.hash:bom", version.ref = "kotlincrypto-hash" }
 kotlincrypto-hash-sha2 = { module = "org.kotlincrypto.hash:sha2", version.ref = "kotlincrypto-hash" }
+
+java-keyring = { module = "com.github.javakeyring:java-keyring", version.ref = "java-keyring" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/oidc-tokenstore/build.gradle.kts
+++ b/oidc-tokenstore/build.gradle.kts
@@ -35,6 +35,12 @@ kotlin {
             }
         }
 
+        val jvmMain by getting {
+            dependencies {
+                implementation(libs.java.keyring)
+            }
+        }
+
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test"))

--- a/oidc-tokenstore/src/jvmMain/kotlin/org/publicvalue/multiplatform/oidc/tokenstore/JvmKeyringSettingsStore.kt
+++ b/oidc-tokenstore/src/jvmMain/kotlin/org/publicvalue/multiplatform/oidc/tokenstore/JvmKeyringSettingsStore.kt
@@ -81,12 +81,12 @@ class JvmKeyringSettingsStore(
         }
 
         keysToRemove.forEach { remove(it) }
-        
+
         // Also explicitly attempt removal of known SettingsKey entries
         // in case they were written before this instance was created (e.g. on a previous app run)
         SettingsKey.entries.forEach { settingsKey ->
-            runCatching { 
-                keyring.deletePassword(serviceName, accountKey(settingsKey.name)) 
+            runCatching {
+                keyring.deletePassword(serviceName, accountKey(settingsKey.name))
             }.onFailure { e ->
                 if (e !is PasswordAccessException) {
                     println("JvmKeyringSettingsStore: failed to clear default key '${settingsKey.name}': ${e.message}")

--- a/oidc-tokenstore/src/jvmMain/kotlin/org/publicvalue/multiplatform/oidc/tokenstore/JvmKeyringSettingsStore.kt
+++ b/oidc-tokenstore/src/jvmMain/kotlin/org/publicvalue/multiplatform/oidc/tokenstore/JvmKeyringSettingsStore.kt
@@ -1,0 +1,97 @@
+package org.publicvalue.multiplatform.oidc.tokenstore
+
+import com.github.javakeyring.Keyring
+import com.github.javakeyring.PasswordAccessException
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.publicvalue.multiplatform.oidc.ExperimentalOpenIdConnect
+
+/**
+ * A [SettingsStore] implementation for JVM desktop that uses the system's native keyring
+ * via the java-keyring library.
+ *
+ * Security guarantees vary by platform and packaging:
+ * - macOS: Strong isolation when distributed via Mac App Store (signed bundle, sandboxed)
+ * - Windows: Strong isolation when distributed via Microsoft Store (MSIX package identity)
+ * - Linux: Encrypted at rest, but no mandatory access control once keyring is unlocked.
+ *   When distributed via Snap, declare the password-manager-service interface in snapcraft.yaml.
+ *
+ * @param serviceName The service name used to namespace entries in the keyring.
+ * @param accountPrefix The prefix used to distinguish token entries from other keyring entries.
+ */
+@ExperimentalOpenIdConnect
+class JvmKeyringSettingsStore(
+    private val serviceName: String = "org.publicvalue.multiplatform.oidc",
+    private val accountPrefix: String = "tokens"
+) : SettingsStore {
+
+    private val mutex = Mutex()
+
+    private val keyring: Keyring by lazy { Keyring.create() }
+    private val writtenKeys = mutableSetOf<String>()
+
+    private fun accountKey(key: String) = "$accountPrefix:$key"
+
+    override suspend fun get(key: String): String? {
+        return try {
+            keyring.getPassword(serviceName, accountKey(key))
+        } catch (e: PasswordAccessException) {
+            // Key not found - this is expected when tokens haven't been stored yet
+            null
+        } catch (e: Exception) {
+            println("JvmKeyringSettingsStore: failed to read key '$key': ${e.message}")
+            null
+        }
+    }
+
+    override suspend fun put(key: String, value: String) {
+        try {
+            keyring.setPassword(serviceName, accountKey(key), value)
+            mutex.withLock {
+                writtenKeys.add(key)
+            }
+        } catch (e: Exception) {
+            // Keyring may be unavailable (e.g. no Secret Service daemon on Linux,
+            // or keychain locked on macOS). Log and rethrow so callers are aware.
+            println("JvmKeyringSettingsStore: failed to write key '$key': ${e.message}")
+            throw e
+        }
+    }
+
+    override suspend fun remove(key: String) {
+        try {
+            keyring.deletePassword(serviceName, accountKey(key))
+            mutex.withLock {
+                writtenKeys.remove(key)
+            }
+        } catch (e: PasswordAccessException) {
+            mutex.withLock {
+                writtenKeys.remove(key)
+            }
+        } catch (e: Exception) {
+            println("JvmKeyringSettingsStore: failed to remove key '$key': ${e.message}")
+        }
+    }
+
+    override suspend fun clear() {
+        val keysToRemove = mutex.withLock {
+            val keys = writtenKeys.toSet()
+            writtenKeys.clear()
+            keys
+        }
+
+        keysToRemove.forEach { remove(it) }
+        
+        // Also explicitly attempt removal of known SettingsKey entries
+        // in case they were written before this instance was created (e.g. on a previous app run)
+        SettingsKey.entries.forEach { settingsKey ->
+            runCatching { 
+                keyring.deletePassword(serviceName, accountKey(settingsKey.name)) 
+            }.onFailure { e ->
+                if (e !is PasswordAccessException) {
+                    println("JvmKeyringSettingsStore: failed to clear default key '${settingsKey.name}': ${e.message}")
+                }
+            }
+        }
+    }
+}

--- a/oidc-tokenstore/src/jvmMain/kotlin/org/publicvalue/multiplatform/oidc/tokenstore/JvmKeyringTokenStore.kt
+++ b/oidc-tokenstore/src/jvmMain/kotlin/org/publicvalue/multiplatform/oidc/tokenstore/JvmKeyringTokenStore.kt
@@ -1,0 +1,38 @@
+package org.publicvalue.multiplatform.oidc.tokenstore
+
+import org.publicvalue.multiplatform.oidc.ExperimentalOpenIdConnect
+
+/**
+ * A [TokenStore] implementation for JVM desktop that persists tokens
+ * in the system's native keyring using java-keyring.
+ *
+ * Uses [JvmKeyringSettingsStore] backed by:
+ * - macOS Keychain (via Security framework / JNA)
+ * - Windows Credential Manager (via WinCred API)
+ * - Linux Secret Service / KWallet (via D-Bus)
+ *
+ * Inherits concurrency-safe token management and flow support
+ * from [SettingsTokenStore].
+ *
+ * Usage:
+ * ```
+ * val tokenStore = JvmKeyringTokenStore(
+ *     serviceName = "com.mycompany.myapp"
+ * )
+ * ```
+ *
+ * @param serviceName A reverse-DNS style identifier for your app, used to namespace
+ *   keyring entries. Should be unique to your application.
+ * @param accountPrefix A prefix for individual token entries within the service namespace.
+ */
+@ExperimentalOpenIdConnect
+@Suppress("unused")
+class JvmKeyringTokenStore(
+    serviceName: String = "org.publicvalue.multiplatform.oidc",
+    accountPrefix: String = "tokens"
+) : SettingsTokenStore(
+    settings = JvmKeyringSettingsStore(
+        serviceName = serviceName,
+        accountPrefix = accountPrefix
+    )
+)

--- a/sample-app/shared/src/jvmMain/kotlin/main.desktop.kt
+++ b/sample-app/shared/src/jvmMain/kotlin/main.desktop.kt
@@ -15,7 +15,7 @@ fun MainView() {
     val navigator = rememberCircuitNavigator(backstack) {
     }
 
-    val settingsStore = JvmSettingsStore()
+    val settingsStore = remember { JvmSettingsStore() }
 
     App(
         backstack = backstack,


### PR DESCRIPTION
Hi, thanks for contributing to this project!

Checklist for your PR:
- [ ] Check if there's any open issue
- [ ] Please file your request against the _main_ branch

# Description of your changes
This PR implements secure token storage for JVM/Desktop targets using the java-keyring library, as discussed in #137 .
Previously, desktop token storage was either non-existent in the library or assumed to use insecure plain-text files. This contribution introduces:

1. JvmKeyringSettingsStore: A thread-safe implementation of SettingsStore that interfaces with native OS credential managers:
  - macOS: Keychain (via Security framework)
  - Windows: Credential Manager (via WinCred API)
  - Linux: Secret Service / KWallet (via D-Bus)

2. JvmKeyringTokenStore: A high-level TokenStore entry point for Desktop apps, mirroring the patterns used for AndroidSettingsTokenStore and IosKeychainTokenStore.
3. Optimized Performance: Reuses the native keyring connection via lazy initialization to avoid repetitive JNA overhead.
4. Improved Documentation: Includes KDocs explaining platform-specific security guarantees and the importance of app packaging (e.g., MSIX/App Bundle) to ensure proper process isolation.

# How has this been tested?

- Manual Verification (macOS): Integrated the JvmKeyringTokenStore into the sample-app (Desktop target).
-   Verified that tokens are successfully written to and read from the macOS System Keychain using the Keychain Access utility.
- Confirmed that the Mutex implementation correctly handles concurrent access within the store.


# Is this a (API-) breaking change?
No. This is a purely additive change that provides new platform-specific implementations without modifying existing common APIs.

