### PR TITLE
Add Android ephemeral Custom Tabs fallback policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ You will need some basic project setup to handle redirect urls and create an ins
 
 [Setup Wasm](docs/setup-wasm.md)
 
+On Android, `AndroidCodeAuthFlowFactory(ephemeralSession = true)` uses ephemeral Custom Tabs when
+the selected browser supports them. If it does not, the default fallback is a private WebView; callers
+can explicitly choose a normal Custom Tab fallback for compatibility. See
+[Ephemeral authorization sessions](docs/setup-android.md#ephemeral-authorization-sessions).
+
 ## OpenID Configuration
 Create an [OpenIdConnectClient](https://kalinjul.github.io/kotlin-multiplatform-oidc/kotlin-multiplatform-oidc/org.publicvalue.multiplatform.oidc/-open-id-connect-client/index.html):
 ```kotlin

--- a/docs/setup-android.md
+++ b/docs/setup-android.md
@@ -38,6 +38,45 @@ class MainActivity : ComponentActivity() {
 > will attach to the ComponentActivity's lifecycle.
 > If you don't use ComponentActivity, you'll need to implement your own Factory.
 
+### Ephemeral authorization sessions
+
+`AndroidCodeAuthFlowFactory` supports ephemeral authorization sessions:
+
+```kotlin
+val codeAuthFlowFactory = AndroidCodeAuthFlowFactory(
+    ephemeralSession = true,
+)
+```
+
+When using Custom Tabs, the selected browser must support ephemeral Custom Tabs. If it does,
+the library launches an ephemeral Custom Tab. If it does not, the library uses
+`UnsupportedEphemeralCustomTabsFallback.PrivateWebView` by default:
+
+```kotlin
+val codeAuthFlowFactory = AndroidCodeAuthFlowFactory(
+    ephemeralSession = true,
+    unsupportedEphemeralCustomTabsFallback = UnsupportedEphemeralCustomTabsFallback.PrivateWebView,
+)
+```
+
+The private WebView fallback clears WebView cookies, storage, cache, and history before and after
+the session. Android WebView does not provide the same isolated ephemeral browser profile as
+supported ephemeral Custom Tabs, but this avoids silently reusing the user's regular browser cookies
+and SSO session.
+
+If you prefer the old compatibility behavior, explicitly opt into launching a normal Custom Tab when
+ephemeral Custom Tabs are unsupported:
+
+```kotlin
+val codeAuthFlowFactory = AndroidCodeAuthFlowFactory(
+    ephemeralSession = true,
+    unsupportedEphemeralCustomTabsFallback = UnsupportedEphemeralCustomTabsFallback.NormalCustomTab,
+)
+```
+
+`NormalCustomTab` may reuse the user's existing browser cookies and SSO session even when
+`ephemeralSession` is `true`. This fallback applies to login and end-session web flows.
+
 ## Login/Logout continuation
 As the actual authentication is performed in a Web Browser, it is possible, especially on low-end devices, that your application is terminated while in background.
 This behaviour can be forced by using ```adb shell am kill <app id>```.

--- a/oidc-appsupport/build.gradle.kts
+++ b/oidc-appsupport/build.gradle.kts
@@ -66,6 +66,12 @@ kotlin {
             dependencies {
             }
         }
+
+        val androidUnitTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
     }
 
     exportKdoc()

--- a/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/AndroidCodeAuthFlowFactory.kt
+++ b/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/AndroidCodeAuthFlowFactory.kt
@@ -39,13 +39,28 @@ class AndroidCodeAuthFlowFactory(
 
     /**
      * If `true`, the authorization session will be ephemeral:
-     * cookies, cache, and other session data will be cleared before starting
-     * the flow in both WebView and Custom Tabs (if supported).
+     * cookies, cache, and other session data will be cleared before starting the flow in WebView.
+     * For Custom Tabs, ephemeral browsing is used when supported by the selected provider.
+     * If the selected provider does not support ephemeral browsing,
+     * [unsupportedEphemeralCustomTabsFallback] decides whether to use a private WebView fallback or
+     * continue with a normal Custom Tab.
      */
     private val ephemeralSession: Boolean = false,
-    /** preferred custom tab providers, list of package names in order of priority. Check [Browser][org.publicvalue.multiplatform.oidc.appsupport.customtab.Browser] for example values. **/
+
+    /**
+     * Preferred custom tab providers, list of package names in order of priority.
+     *
+     * Check [Browser][org.publicvalue.multiplatform.oidc.appsupport.customtab.Browser] for example values.
+     */
     private val customTabProviderPriority: List<String> = listOf(),
-): CodeAuthFlowFactory {
+
+    /**
+     * Fallback used when [ephemeralSession] is `true` and the selected Custom Tabs provider does
+     * not support ephemeral browsing.
+     */
+    private val unsupportedEphemeralCustomTabsFallback: UnsupportedEphemeralCustomTabsFallback =
+        UnsupportedEphemeralCustomTabsFallback.PrivateWebView,
+) : CodeAuthFlowFactory {
 
     private lateinit var activityResultLauncher: ActivityResultLauncherSuspend<Intent, ActivityResult>
     private lateinit var context: Context
@@ -59,6 +74,17 @@ class AndroidCodeAuthFlowFactory(
     constructor(activity: ComponentActivity, useWebView: Boolean = false) : this(useWebView = useWebView) {
         registerActivity(activity)
     }
+
+    constructor(
+        useWebView: Boolean = false,
+        ephemeralSession: Boolean = false,
+        customTabProviderPriority: List<String> = listOf(),
+    ) : this(
+        useWebView = useWebView,
+        ephemeralSession = ephemeralSession,
+        customTabProviderPriority = customTabProviderPriority,
+        unsupportedEphemeralCustomTabsFallback = UnsupportedEphemeralCustomTabsFallback.PrivateWebView,
+    )
 
     /**
      * Registers a lifecycle observer to be able to start a browser when required for login.
@@ -117,14 +143,15 @@ class AndroidCodeAuthFlowFactory(
             WebViewFlow(
                 context = context,
                 contract = activityResultLauncher,
-                epheremalSession = ephemeralSession
+                ephemeralSession = ephemeralSession
             )
         } else {
             CustomTabFlow(
                 context = context,
                 contract = activityResultLauncher,
-                epheremalSession = ephemeralSession,
+                ephemeralSession = ephemeralSession,
                 preferredBrowserPackage = preferredBrowserPackage,
+                unsupportedEphemeralCustomTabsFallback = unsupportedEphemeralCustomTabsFallback,
             )
         }
         return webFlow

--- a/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/EphemeralCustomTabsPolicy.kt
+++ b/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/EphemeralCustomTabsPolicy.kt
@@ -1,0 +1,26 @@
+package org.publicvalue.multiplatform.oidc.appsupport
+
+internal enum class EphemeralCustomTabsLaunchMode {
+    EphemeralCustomTab,
+    NormalCustomTab,
+    PrivateWebView,
+}
+
+internal fun resolveEphemeralCustomTabsLaunchMode(
+    ephemeralSession: Boolean,
+    ephemeralBrowsingSupported: Boolean,
+    unsupportedEphemeralCustomTabsFallback: UnsupportedEphemeralCustomTabsFallback,
+): EphemeralCustomTabsLaunchMode {
+    if (!ephemeralSession) {
+        return EphemeralCustomTabsLaunchMode.NormalCustomTab
+    }
+
+    if (ephemeralBrowsingSupported) {
+        return EphemeralCustomTabsLaunchMode.EphemeralCustomTab
+    }
+
+    return when (unsupportedEphemeralCustomTabsFallback) {
+        UnsupportedEphemeralCustomTabsFallback.PrivateWebView -> EphemeralCustomTabsLaunchMode.PrivateWebView
+        UnsupportedEphemeralCustomTabsFallback.NormalCustomTab -> EphemeralCustomTabsLaunchMode.NormalCustomTab
+    }
+}

--- a/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/HandleRedirectActivity.kt
+++ b/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/HandleRedirectActivity.kt
@@ -8,6 +8,7 @@ import android.webkit.CookieManager
 import android.webkit.WebChromeClient
 import android.webkit.WebResourceRequest
 import android.webkit.WebSettings
+import android.webkit.WebStorage
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.activity.ComponentActivity
@@ -28,8 +29,12 @@ internal const val EXTRA_KEY_EPHEMERAL_SESSION = "ephemeral_session"
 internal const val EXTRA_KEY_REDIRECTURL = "redirecturl"
 internal const val EXTRA_KEY_URL = "url"
 internal const val EXTRA_KEY_PACKAGE_NAME = "package"
+internal const val EXTRA_KEY_UNSUPPORTED_EPHEMERAL_CUSTOM_TABS_FALLBACK = "unsupported_ephemeral_custom_tabs_fallback"
 
 class HandleRedirectActivity : ComponentActivity() {
+
+    private var clearWebViewDataOnDestroy = false
+    private var currentWebView: WebView? = null
 
     companion object {
         /** Set to use your own web settings when using WebView **/
@@ -79,7 +84,7 @@ class HandleRedirectActivity : ComponentActivity() {
         }
 
         @ExperimentalOpenIdConnect
-        var showWebView: ComponentActivity.(url: String, redirectUrl: String?, epheremalSession: Boolean) -> Unit = { url, redirectUrl, epheremalSession ->
+        var showWebView: ComponentActivity.(url: String, redirectUrl: String?, ephemeralSession: Boolean) -> Unit = { url, redirectUrl, ephemeralSession ->
             val webView = createWebView(this, redirectUrl)
             ViewCompat.setOnApplyWindowInsetsListener(webView) { view, windowInsets ->
                 val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
@@ -91,10 +96,12 @@ class HandleRedirectActivity : ComponentActivity() {
                 }
                 WindowInsetsCompat.CONSUMED
             }
-            if (epheremalSession) {
-                CookieManager.getInstance().removeAllCookies(null)
-                webView.clearHistory()
-                webView.clearCache(true)
+            if (ephemeralSession) {
+                (this as? HandleRedirectActivity)?.apply {
+                    clearWebViewSessionData(webView)
+                    clearWebViewDataOnDestroy = true
+                    currentWebView = webView
+                }
             }
             setContentView(webView)
             webView.loadUrl(url)
@@ -120,6 +127,10 @@ class HandleRedirectActivity : ComponentActivity() {
         val ephemeralSession = intent.extras?.getBoolean(EXTRA_KEY_EPHEMERAL_SESSION)
         val url = intent.extras?.getString(EXTRA_KEY_URL)
         val redirectUrl = intent.extras?.getString(EXTRA_KEY_REDIRECTURL)
+        val unsupportedEphemeralCustomTabsFallback = intent.extras
+            ?.getString(EXTRA_KEY_UNSUPPORTED_EPHEMERAL_CUSTOM_TABS_FALLBACK)
+            ?.toUnsupportedEphemeralCustomTabsFallback()
+            ?: UnsupportedEphemeralCustomTabsFallback.PrivateWebView
 
         if (intent?.data != null) {
             // we're called by custom tab
@@ -146,13 +157,14 @@ class HandleRedirectActivity : ComponentActivity() {
                 val preferredBrowserPackage = intent.extras?.getString(EXTRA_KEY_PACKAGE_NAME)
                 intent.removeExtra(EXTRA_KEY_PACKAGE_NAME)
                 if (useWebView == true) {
-                    showWebView(url, redirectUrl, ephemeralSession ?: false)
+                    showWebViewSession(url, redirectUrl, ephemeralSession ?: false)
                 } else {
                     launchCustomTabsIntent(
                         url,
                         redirectUrl,
                         preferredBrowserPackage,
-                        ephemeralSession
+                        ephemeralSession,
+                        unsupportedEphemeralCustomTabsFallback
                     )
                 }
             }
@@ -164,15 +176,27 @@ class HandleRedirectActivity : ComponentActivity() {
         url: String,
         redirectUrl: String?,
         preferredBrowserPackage: String?,
-        ephemeralSession: Boolean?
+        ephemeralSession: Boolean?,
+        unsupportedEphemeralCustomTabsFallback: UnsupportedEphemeralCustomTabsFallback
     ) {
         val builder = CustomTabsIntent.Builder()
         builder.configureCustomTabsIntent()
 
+        val ephemeralSessionRequested = ephemeralSession ?: false
         if (preferredBrowserPackage != null) {
-            // Enable ephemeral browsing if supported
-            if (CustomTabsClient.isEphemeralBrowsingSupported(this, preferredBrowserPackage)) {
-                builder.setEphemeralBrowsingEnabled(ephemeralSession ?: false)
+            val launchMode = resolveEphemeralCustomTabsLaunchMode(
+                ephemeralSession = ephemeralSessionRequested,
+                ephemeralBrowsingSupported = CustomTabsClient.isEphemeralBrowsingSupported(this, preferredBrowserPackage),
+                unsupportedEphemeralCustomTabsFallback = unsupportedEphemeralCustomTabsFallback
+            )
+
+            when (launchMode) {
+                EphemeralCustomTabsLaunchMode.EphemeralCustomTab -> builder.setEphemeralBrowsingEnabled(true)
+                EphemeralCustomTabsLaunchMode.PrivateWebView -> {
+                    showWebViewSession(url, redirectUrl, true)
+                    return
+                }
+                EphemeralCustomTabsLaunchMode.NormalCustomTab -> Unit
             }
         }
 
@@ -183,8 +207,33 @@ class HandleRedirectActivity : ComponentActivity() {
             intent.launchUrl(this, url.toUri())
         } catch (_: ActivityNotFoundException) {
             // If there is no browser activity available, fallback to WebView
-            showWebView(url, redirectUrl, ephemeralSession ?: false)
+            showWebViewSession(url, redirectUrl, ephemeralSessionRequested)
         }
+    }
+
+    @OptIn(ExperimentalOpenIdConnect::class)
+    private fun showWebViewSession(url: String, redirectUrl: String?, ephemeralSession: Boolean) {
+        intent.putExtra(EXTRA_KEY_USEWEBVIEW, true)
+        showWebView(url, redirectUrl, ephemeralSession)
+    }
+
+    private fun clearWebViewSessionData(webView: WebView?) {
+        CookieManager.getInstance().apply {
+            removeAllCookies(null)
+            flush()
+        }
+        WebStorage.getInstance().deleteAllData()
+        webView?.clearHistory()
+        webView?.clearCache(true)
+    }
+
+    override fun onDestroy() {
+        if (clearWebViewDataOnDestroy) {
+            clearWebViewSessionData(currentWebView)
+            currentWebView = null
+            clearWebViewDataOnDestroy = false
+        }
+        super.onDestroy()
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -192,3 +241,6 @@ class HandleRedirectActivity : ComponentActivity() {
         setIntent(intent)
     }
 }
+
+private fun String.toUnsupportedEphemeralCustomTabsFallback(): UnsupportedEphemeralCustomTabsFallback? =
+    UnsupportedEphemeralCustomTabsFallback.entries.firstOrNull { it.name == this }

--- a/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/UnsupportedEphemeralCustomTabsFallback.kt
+++ b/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/UnsupportedEphemeralCustomTabsFallback.kt
@@ -1,0 +1,23 @@
+package org.publicvalue.multiplatform.oidc.appsupport
+
+/**
+ * Fallback behavior for Android authorization flows when [AndroidCodeAuthFlowFactory] requests an
+ * ephemeral session but the selected Custom Tabs provider does not support ephemeral browsing.
+ */
+enum class UnsupportedEphemeralCustomTabsFallback {
+    /**
+     * Use the embedded WebView path and clear WebView state before and after the session.
+     *
+     * Android WebView does not provide the same isolated ephemeral browser profile as supported
+     * ephemeral Custom Tabs. This is the privacy-preserving fallback available to the library.
+     */
+    PrivateWebView,
+
+    /**
+     * Launch a normal Custom Tab even though ephemeral Custom Tabs are unsupported.
+     *
+     * This may reuse the user's existing browser cookies and SSO session even when
+     * `ephemeralSession` is `true`.
+     */
+    NormalCustomTab,
+}

--- a/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/customtab/CustomTabFlow.kt
+++ b/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/customtab/CustomTabFlow.kt
@@ -8,8 +8,10 @@ import org.publicvalue.multiplatform.oidc.appsupport.ActivityResultLauncherSuspe
 import org.publicvalue.multiplatform.oidc.appsupport.EXTRA_KEY_EPHEMERAL_SESSION
 import org.publicvalue.multiplatform.oidc.appsupport.EXTRA_KEY_PACKAGE_NAME
 import org.publicvalue.multiplatform.oidc.appsupport.EXTRA_KEY_REDIRECTURL
+import org.publicvalue.multiplatform.oidc.appsupport.EXTRA_KEY_UNSUPPORTED_EPHEMERAL_CUSTOM_TABS_FALLBACK
 import org.publicvalue.multiplatform.oidc.appsupport.EXTRA_KEY_URL
 import org.publicvalue.multiplatform.oidc.appsupport.HandleRedirectActivity
+import org.publicvalue.multiplatform.oidc.appsupport.UnsupportedEphemeralCustomTabsFallback
 import org.publicvalue.multiplatform.oidc.appsupport.WebAuthenticationFlow
 import org.publicvalue.multiplatform.oidc.appsupport.WebAuthenticationFlowResult
 import org.publicvalue.multiplatform.oidc.appsupport.util.toAuthenticationFlowResult
@@ -17,9 +19,10 @@ import org.publicvalue.multiplatform.oidc.appsupport.util.toAuthenticationFlowRe
 internal class CustomTabFlow(
     private val context: Context,
     private val contract: ActivityResultLauncherSuspend<Intent, ActivityResult>,
-    private val epheremalSession: Boolean,
+    private val ephemeralSession: Boolean,
     private val preferredBrowserPackage: String,
-): WebAuthenticationFlow {
+    private val unsupportedEphemeralCustomTabsFallback: UnsupportedEphemeralCustomTabsFallback,
+) : WebAuthenticationFlow {
     override suspend fun startWebFlow(requestUrl: Url, redirectUrl: String): WebAuthenticationFlowResult {
         val intent = prepareIntent(requestUrl = requestUrl.toString(), redirectUrl = redirectUrl)
         val result = contract.launchSuspend(intent)
@@ -35,7 +38,11 @@ internal class CustomTabFlow(
                 this.putExtra(EXTRA_KEY_URL, requestUrl)
                 this.putExtra(EXTRA_KEY_PACKAGE_NAME, preferredBrowserPackage)
                 this.putExtra(EXTRA_KEY_REDIRECTURL, redirectUrl) // if fallback to webview is triggered
-                this.putExtra(EXTRA_KEY_EPHEMERAL_SESSION, epheremalSession)
+                this.putExtra(EXTRA_KEY_EPHEMERAL_SESSION, ephemeralSession)
+                this.putExtra(
+                    EXTRA_KEY_UNSUPPORTED_EPHEMERAL_CUSTOM_TABS_FALLBACK,
+                    unsupportedEphemeralCustomTabsFallback.name
+                )
             }
         return intent
     }

--- a/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/webview/WebViewFlow.kt
+++ b/oidc-appsupport/src/androidMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/webview/WebViewFlow.kt
@@ -10,8 +10,8 @@ import org.publicvalue.multiplatform.oidc.appsupport.util.toAuthenticationFlowRe
 internal class WebViewFlow(
     private val context: Context,
     private val contract: ActivityResultLauncherSuspend<Intent, ActivityResult>,
-    private val epheremalSession: Boolean,
-): WebAuthenticationFlow {
+    private val ephemeralSession: Boolean,
+) : WebAuthenticationFlow {
     override suspend fun startWebFlow(requestUrl: Url, redirectUrl: String): WebAuthenticationFlowResult {
         val intent = prepareIntent(requestUrl = requestUrl.toString(), redirectUrl = redirectUrl)
         val result = contract.launchSuspend(intent)
@@ -27,7 +27,7 @@ internal class WebViewFlow(
                 this.putExtra(EXTRA_KEY_URL, requestUrl)
                 this.putExtra(EXTRA_KEY_USEWEBVIEW, true)
                 this.putExtra(EXTRA_KEY_REDIRECTURL, redirectUrl)
-                this.putExtra(EXTRA_KEY_EPHEMERAL_SESSION, epheremalSession)
+                this.putExtra(EXTRA_KEY_EPHEMERAL_SESSION, ephemeralSession)
             }
         return intent
     }

--- a/oidc-appsupport/src/androidUnitTest/kotlin/README.kt
+++ b/oidc-appsupport/src/androidUnitTest/kotlin/README.kt
@@ -4,6 +4,7 @@ import io.ktor.client.request.header
 import org.publicvalue.multiplatform.oidc.ExperimentalOpenIdConnect
 import org.publicvalue.multiplatform.oidc.OpenIdConnectClient
 import org.publicvalue.multiplatform.oidc.appsupport.AndroidCodeAuthFlowFactory
+import org.publicvalue.multiplatform.oidc.appsupport.UnsupportedEphemeralCustomTabsFallback
 import org.publicvalue.multiplatform.oidc.flows.CodeAuthFlowFactory
 import org.publicvalue.multiplatform.oidc.tokenstore.TokenRefreshHandler
 import org.publicvalue.multiplatform.oidc.tokenstore.TokenStore
@@ -55,6 +56,13 @@ object README {
                 factory.registerActivity(this)
             }
         }
+    }
+
+    fun `Create_ephemeral_AuthFlowFactory`() {
+        AndroidCodeAuthFlowFactory(
+            ephemeralSession = true,
+            unsupportedEphemeralCustomTabsFallback = UnsupportedEphemeralCustomTabsFallback.PrivateWebView,
+        )
     }
 
     // Request access token using code auth flow

--- a/oidc-appsupport/src/androidUnitTest/kotlin/org/publicvalue/multiplatform/oidc/appsupport/EphemeralCustomTabsPolicyTest.kt
+++ b/oidc-appsupport/src/androidUnitTest/kotlin/org/publicvalue/multiplatform/oidc/appsupport/EphemeralCustomTabsPolicyTest.kt
@@ -1,0 +1,50 @@
+package org.publicvalue.multiplatform.oidc.appsupport
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class EphemeralCustomTabsPolicyTest {
+    @Test
+    fun `normal sessions use normal Custom Tabs even if ephemeral browsing is unsupported`() {
+        val mode = resolveEphemeralCustomTabsLaunchMode(
+            ephemeralSession = false,
+            ephemeralBrowsingSupported = false,
+            unsupportedEphemeralCustomTabsFallback = UnsupportedEphemeralCustomTabsFallback.PrivateWebView
+        )
+
+        assertEquals(EphemeralCustomTabsLaunchMode.NormalCustomTab, mode)
+    }
+
+    @Test
+    fun `ephemeral sessions use ephemeral Custom Tabs when supported`() {
+        val mode = resolveEphemeralCustomTabsLaunchMode(
+            ephemeralSession = true,
+            ephemeralBrowsingSupported = true,
+            unsupportedEphemeralCustomTabsFallback = UnsupportedEphemeralCustomTabsFallback.PrivateWebView
+        )
+
+        assertEquals(EphemeralCustomTabsLaunchMode.EphemeralCustomTab, mode)
+    }
+
+    @Test
+    fun `ephemeral sessions use private WebView fallback by default when unsupported`() {
+        val mode = resolveEphemeralCustomTabsLaunchMode(
+            ephemeralSession = true,
+            ephemeralBrowsingSupported = false,
+            unsupportedEphemeralCustomTabsFallback = UnsupportedEphemeralCustomTabsFallback.PrivateWebView
+        )
+
+        assertEquals(EphemeralCustomTabsLaunchMode.PrivateWebView, mode)
+    }
+
+    @Test
+    fun `ephemeral sessions can opt into normal Custom Tab fallback when unsupported`() {
+        val mode = resolveEphemeralCustomTabsLaunchMode(
+            ephemeralSession = true,
+            ephemeralBrowsingSupported = false,
+            unsupportedEphemeralCustomTabsFallback = UnsupportedEphemeralCustomTabsFallback.NormalCustomTab
+        )
+
+        assertEquals(EphemeralCustomTabsLaunchMode.NormalCustomTab, mode)
+    }
+}


### PR DESCRIPTION
Checklist for your PR:
- [x] Check if there's any open issue
- [x] Please file your request against the _main_ branch

# Description of your changes
Adds a configurable Android fallback for ephemeral Custom Tabs when the selected Custom Tabs provider does not support ephemeral browsing.

By default, `AndroidCodeAuthFlowFactory(ephemeralSession = true)` now falls back to a private WebView path instead of silently launching a normal Custom Tab that may reuse browser cookies or SSO state. Callers that need the old compatibility behavior can opt into `UnsupportedEphemeralCustomTabsFallback.NormalCustomTab`.

The change also:
- preserves the existing Android/JVM constructor ABI for already-compiled consumers
- keeps WebView fallback state represented as a WebView session across later activity resumes
- clears WebView cookies, storage, cache, and history before and after private WebView sessions
- documents the behavior in the README and Android setup guide

# Is this a (API-) breaking change?

No. This adds a new opt-in fallback enum and constructor parameter while preserving the previous Android/JVM constructor ABI. The default runtime behavior for `ephemeralSession = true` changes to prefer a privacy-preserving WebView fallback when ephemeral Custom Tabs are unsupported; callers can explicitly opt into the previous normal Custom Tab behavior with `UnsupportedEphemeralCustomTabsFallback.NormalCustomTab`.
