### PR TITLE
Support opening browser on Linux

### DIFF
--- a/oidc-appsupport/src/jvmMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/DesktopPlatform.kt
+++ b/oidc-appsupport/src/jvmMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/DesktopPlatform.kt
@@ -1,0 +1,20 @@
+package org.publicvalue.multiplatform.oidc.appsupport
+
+internal enum class DesktopPlatform {
+    Windows,
+    Linux,
+    MacOS,
+    Unknown;
+
+    companion object {
+        val Current by lazy {
+            val osName = System.getProperty("os.name").orEmpty().lowercase()
+            when {
+                osName.startsWith("win") -> Windows
+                osName.startsWith("mac") -> MacOS
+                osName.startsWith("linux") -> Linux
+                else -> Unknown
+            }
+        }
+    }
+}

--- a/oidc-appsupport/src/jvmMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/JvmCodeAuthFlowFactory.kt
+++ b/oidc-appsupport/src/jvmMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/JvmCodeAuthFlowFactory.kt
@@ -57,6 +57,13 @@ private fun Url.openInBrowser() {
             throw UrlOpenException(e.message, cause = e)
         }
     } else {
-        throw UrlOpenException("Desktop does not support Browse Action")
+        when (val current = DesktopPlatform.Current) {
+            DesktopPlatform.Linux ->
+                Runtime.getRuntime().exec(arrayOf("xdg-open", toURI().toString()))
+            DesktopPlatform.Windows, DesktopPlatform.MacOS ->
+                throw UrlOpenException("AWT doesn't support the BROWSE action on $current")
+            DesktopPlatform.Unknown ->
+                throw UrlOpenException("AWT doesn't support $current")
+        }
     }
 }


### PR DESCRIPTION
Hi, thanks for contributing to this project!

Checklist for your PR:
- [x] Check if there's any open issue
- [x] Please file your request against the _main_ branch

# Description of your changes
Fixes issue #178. On Linux using AWT Browser Action wasn't working, so I used `xdg-open` to open such URLs in case we detected that we're on Linux. For Windows and Mac OS, assuming that AWT Browser action doesn't work there, I'm throwing an exception for now.

# How has this been tested?

Before

<img width="797" height="613" alt="image" src="https://github.com/user-attachments/assets/32b720a4-c248-4786-abb0-092043bea6b1" />

After
OAuth link was opened in my default browser and I was able to complete the login flow.

<img width="787" height="791" alt="image" src="https://github.com/user-attachments/assets/7e59d824-1590-4e96-b9b8-77d44a21ee5b" />


# Is this a (API-) breaking change?
No it's not, no public interface was touched.
