### PR TITLE
Support https redirect URIs on iOS via ASWebAuthenticationSession callback matching

### DIFF
--- a/oidc-appsupport/build.gradle.kts
+++ b/oidc-appsupport/build.gradle.kts
@@ -62,6 +62,7 @@ kotlin {
 
         val commonTest by getting {
             dependencies {
+                implementation(kotlin("test"))
             }
         }
     }

--- a/oidc-appsupport/src/iosMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/WebSessionFlow.kt
+++ b/oidc-appsupport/src/iosMain/kotlin/org/publicvalue/multiplatform/oidc/appsupport/WebSessionFlow.kt
@@ -1,6 +1,9 @@
 package org.publicvalue.multiplatform.oidc.appsupport
 
+import io.ktor.http.URLProtocol
 import io.ktor.http.Url
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.cValue
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -11,6 +14,10 @@ import org.publicvalue.multiplatform.oidc.preferences.setResponseUri
 import platform.AuthenticationServices.ASPresentationAnchor
 import platform.AuthenticationServices.ASWebAuthenticationPresentationContextProvidingProtocol
 import platform.AuthenticationServices.ASWebAuthenticationSession
+import platform.AuthenticationServices.ASWebAuthenticationSessionCallback
+import platform.Foundation.NSError
+import platform.Foundation.NSOperatingSystemVersion
+import platform.Foundation.NSProcessInfo
 import platform.Foundation.NSURL
 import platform.darwin.NSObject
 
@@ -25,22 +32,34 @@ internal class WebSessionFlow(
         return suspendCancellableCoroutine { continuation ->
             val nsurl = NSURL.URLWithString(requestUrl.toString())
             if (nsurl != null) {
-                val session = ASWebAuthenticationSession(
-                    uRL = nsurl,
-                    callbackURLScheme = Url(redirectUrl).protocol.name,
-                    completionHandler = { url, error ->
-                        if (url != null) {
-                            val url = Url(url.toString()) // use sane url instead of NS garbage
-                            runBlocking {
-                                preferences.setResponseUri(url)
-                            }
-                            continuation.resumeIfActive(WebAuthenticationFlowResult.Success(url))
-                        } else {
-                            // browser closed, no redirect.
-                            continuation.resumeIfActive(WebAuthenticationFlowResult.Cancelled)
+                val completionHandler: (NSURL?, NSError?) -> Unit = { url, _ ->
+                    if (url != null) {
+                        val url = Url(url.toString()) // use sane url instead of NS garbage
+                        runBlocking {
+                            preferences.setResponseUri(url)
                         }
+                        continuation.resumeIfActive(WebAuthenticationFlowResult.Success(url))
+                    } else {
+                        // browser closed, no redirect.
+                        continuation.resumeIfActive(WebAuthenticationFlowResult.Cancelled)
                     }
-                )
+                }
+
+                val redirect = Url(redirectUrl)
+                val httpsCallback = redirect.httpsCallbackOrNull()
+                val session = if (httpsCallback != null) {
+                    ASWebAuthenticationSession(
+                        uRL = nsurl,
+                        callback = httpsCallback,
+                        completionHandler = completionHandler
+                    )
+                } else {
+                    ASWebAuthenticationSession(
+                        uRL = nsurl,
+                        callbackURLScheme = redirect.protocol.name,
+                        completionHandler = completionHandler
+                    )
+                }
                 session.prefersEphemeralWebBrowserSession = ephemeralBrowserSession
                 session.presentationContextProvider = PresentationContext()
 
@@ -52,6 +71,30 @@ internal class WebSessionFlow(
             }
         }
     }
+}
+
+/** ASWebAuthenticationSession callback matching was introduced in iOS 17.4. */
+@OptIn(ExperimentalForeignApi::class)
+internal val supportsCallbackMatching: Boolean by lazy {
+    NSProcessInfo.processInfo.isOperatingSystemAtLeastVersion(
+        cValue<NSOperatingSystemVersion> {
+            majorVersion = 17
+            minorVersion = 4
+            patchVersion = 0
+        }
+    )
+}
+
+/**
+ * Callback matcher for https redirect uris.
+ *
+ * ASWebAuthenticationSession's `callbackURLScheme` parameter only accepts private-use schemes, so
+ * an https redirect uri never completes the flow. Returns null when the redirect uri is not https
+ * or the OS predates callback matching, letting the caller fall back to scheme matching.
+ */
+internal fun Url.httpsCallbackOrNull(): ASWebAuthenticationSessionCallback? {
+    if (protocol != URLProtocol.HTTPS || !supportsCallbackMatching) return null
+    return ASWebAuthenticationSessionCallback.callbackWithHTTPSHost(host = host, path = encodedPath)
 }
 
 private class PresentationContext: NSObject(), ASWebAuthenticationPresentationContextProvidingProtocol {

--- a/oidc-appsupport/src/iosTest/kotlin/org/publicvalue/multiplatform/oidc/appsupport/WebSessionFlowTest.kt
+++ b/oidc-appsupport/src/iosTest/kotlin/org/publicvalue/multiplatform/oidc/appsupport/WebSessionFlowTest.kt
@@ -1,0 +1,39 @@
+package org.publicvalue.multiplatform.oidc.appsupport
+
+import io.ktor.http.Url
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class WebSessionFlowTest {
+
+    @Test
+    fun httpsRedirectUsesCallbackMatchingWhenAvailable() {
+        val callback = Url("https://auth.example.com/auth/callback").httpsCallbackOrNull()
+
+        if (supportsCallbackMatching) {
+            assertNotNull(callback, "https redirect uri should use callback matching on iOS 17.4+")
+        } else {
+            assertNull(callback, "callback matching is unavailable before iOS 17.4")
+        }
+    }
+
+    @Test
+    fun privateUseSchemeFallsBackToSchemeMatching() {
+        assertNull(Url("com.example.app://auth/callback").httpsCallbackOrNull())
+    }
+
+    @Test
+    fun plainHttpFallsBackToSchemeMatching() {
+        assertNull(Url("http://localhost:8080/auth/callback").httpsCallbackOrNull())
+    }
+
+    @Test
+    fun redirectUriIsSplitIntoHostAndPath() {
+        val redirect = Url("https://auth.example.com/auth/callback")
+
+        assertEquals("auth.example.com", redirect.host)
+        assertEquals("/auth/callback", redirect.encodedPath)
+    }
+}


### PR DESCRIPTION
Checklist for your PR:
- [x] Check if there's any open issue — addresses #46
- [x] Please file your request against the _main_ branch

# Description of your changes

Addresses #46 , which asks how to use a plain `https://` redirect URI instead of a private-use scheme. On iOS this is currently impossible, and it fails silently.

`WebSessionFlow` passes the redirect URI's scheme straight to `ASWebAuthenticationSession`:

```kotlin
callbackURLScheme = Url(redirectUrl).protocol.name
```
`callbackURLScheme only accepts private-use schemes, so an https redirect URI becomes `callbackURLScheme = "https"`, which never matches. The completion handler is never invoked and the flow hangs until the user cancels — no error, no callback.

iOS 17.4 introduced `ASWebAuthenticationSessionCallback` together with an `init(url:callback:completionHandler:)` overload, which supports matching against an https host and path. This PR uses it when both conditions hold:

- the redirect URI's scheme is https
- the OS is at least iOS 17.4 (checked at runtime, since Kotlin/Native has no @available)

Anything else — private-use schemes, plain http, devices below 17.4 — takes the existing `callbackURLScheme` path unchanged.

The diff is a little larger than the change itself because `completionHandler` had to be hoisted into a local, as it is now shared by two constructors.

Note that this only covers the iOS half of #46. The Android half needs no library change: consumers can drop the `${oidcRedirectScheme}` placeholder filter with `<intent-filter tools:node="removeAll"/>` and declare their own https intent-filter with `android:autoVerify="true"`.

# How has this been tested?

`oidc-appsupport` had an empty `commonTest` and no iOS test source set, so I added `kotlin("test")` and an `iosTest` source set with four tests covering the selection logic. `./gradlew :oidc-appsupport:iosSimulatorArm64Test` passes with
tests=4 failures=0 skipped=0:

- https redirect URI uses callback matching (asserted against the runtime version check, so the test is also correct on a pre-17.4 simulator)
- private-use scheme falls back to scheme matching
- plain http falls back to scheme matching
- host and path are split as `callbackWithHTTPSHost(host:path:)` expects

Also verified to compile: `compileKotlinIosSimulatorArm64`, `compileTestKotlinIosArm64`, `compileTestKotlinJs`, `compileTestKotlinWasmJs`. I could not run `compileTestKotlinJvm` locally — my machine has JDK 21 but the build requests a 17 toolchain, which is unrelated to this change.

**Not verified end to end.** The tests cover which constructor is chosen, not a live https redirect round-trip — that needs a deployed domain serving `apple-app-site-association`, which I don't have available yet. Happy to test against a real setup if you'd like that before merging.

# Is this a (API-) breaking change?

No. No public API changes, and behaviour is unchanged for every redirect URI that works today. The only additions are two `internal` declarations in `iosMain` and a `kotlin("test")` dependency on `commonTest`.